### PR TITLE
feat: add auto-collected metadata fields to issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,15 +22,51 @@ body:
       label: Expected behavior
       description: What did you expect to happen?
   - type: input
-    id: version
+    id: app-version
     attributes:
-      label: Prosponsive version
-  - type: dropdown
+      label: App Version
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
     id: platform
     attributes:
       label: Platform
-      options:
-        - macOS (Apple Silicon)
-        - macOS (Intel)
-        - Windows
-        - Linux
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: ai-provider
+    attributes:
+      label: AI Provider
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: ai-model
+    attributes:
+      label: AI Model
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: os-version
+    attributes:
+      label: OS Version
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: total-ram
+    attributes:
+      label: Total RAM
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: cpu-cores
+    attributes:
+      label: CPU Cores
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -19,3 +19,52 @@ body:
     attributes:
       label: Alternatives considered
       description: Any workarounds or alternatives you have tried?
+  - type: input
+    id: app-version
+    attributes:
+      label: App Version
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: platform
+    attributes:
+      label: Platform
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: ai-provider
+    attributes:
+      label: AI Provider
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: ai-model
+    attributes:
+      label: AI Model
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: os-version
+    attributes:
+      label: OS Version
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: total-ram
+    attributes:
+      label: Total RAM
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false
+  - type: input
+    id: cpu-cores
+    attributes:
+      label: CPU Cores
+      description: Auto-populated by Prosponsive app
+    validations:
+      required: false


### PR DESCRIPTION
## Summary

- Add input fields for app-version, platform, ai-provider, ai-model, os-version, total-ram, cpu-cores to `bug_report.yml`
- Add the same input fields to `feature_request.yml`
- All fields are optional and described as "Auto-populated by Prosponsive app"
- Companion to jb-brown/Prosponsive#120 which populates these fields programmatically

## Test plan

- [ ] Verify bug report form renders correctly on GitHub with new fields
- [ ] Verify feature request form renders correctly on GitHub with new fields
- [ ] Confirm fields are optional (not required)

Part of jb-brown/Prosponsive#115

Generated with [Claude Code](https://claude.com/claude-code)
