### PR TITLE
feat: enable Windows download on landing page (#267)

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,8 @@
     <section class="requirements" aria-labelledby="requirements-heading">
       <h2 id="requirements-heading">System Requirements</h2>
       <ul>
-        <li><strong>macOS</strong> 12 (Monterey) or later</li>
-        <li><strong>Apple Silicon</strong> (arm64)</li>
-        <li>Intel support: <em>Coming soon</em></li>
+        <li><strong>macOS</strong> 12 (Monterey) or later — Apple Silicon (arm64)</li>
+        <li><strong>Windows</strong> 10 or later — x64 or ARM64</li>
       </ul>
     </section>
   </main>

--- a/js/download.js
+++ b/js/download.js
@@ -2,11 +2,12 @@
   'use strict';
 
   var CLOUDFRONT = 'https://dyk1asoq4bvxx.cloudfront.net';
-  var MANIFEST_URL = CLOUDFRONT + '/latest-mac.yml';
-  var FALLBACK_VERSION = '1.0.9';
+  var MAC_MANIFEST_URL = CLOUDFRONT + '/latest-mac.yml';
+  var WIN_MANIFEST_URL = CLOUDFRONT + '/latest.yml';
 
-  // Cached version info for platform switching
-  var cachedVersionInfo = null;
+  // Cached version info per platform
+  var cachedMacInfo = null;
+  var cachedWinInfo = null;
 
   // ---- Platform detection ----
 
@@ -19,29 +20,45 @@
 
   // ---- Version fetching ----
 
-  function fetchVersionInfo() {
-    return fetch(MANIFEST_URL)
+  function parseManifest(text) {
+    var versionMatch = text.match(/^version:\s*(.+)$/m);
+    var sizeMatch = text.match(/size:\s*(\d+)/);
+
+    var version = versionMatch ? versionMatch[1].trim() : null;
+    var sizeMB = sizeMatch ? Math.round(parseInt(sizeMatch[1], 10) / (1024 * 1024)) : null;
+
+    return { version: version, sizeMB: sizeMB };
+  }
+
+  function fetchManifest(url) {
+    return fetch(url)
       .then(function (response) {
         if (!response.ok) throw new Error('HTTP ' + response.status);
         return response.text();
       })
-      .then(function (text) {
-        var versionMatch = text.match(/^version:\s*(.+)$/m);
-        var sizeMatch = text.match(/size:\s*(\d+)/);
-
-        var version = versionMatch ? versionMatch[1].trim() : null;
-        var sizeMB = sizeMatch ? Math.round(parseInt(sizeMatch[1], 10) / (1024 * 1024)) : null;
-
-        return { version: version, sizeMB: sizeMB };
-      })
+      .then(parseManifest)
       .catch(function () {
         return { version: null, sizeMB: null };
       });
   }
 
+  function fetchAllVersionInfo() {
+    return Promise.all([
+      fetchManifest(MAC_MANIFEST_URL),
+      fetchManifest(WIN_MANIFEST_URL)
+    ]).then(function (results) {
+      cachedMacInfo = results[0];
+      cachedWinInfo = results[1];
+      return { mac: results[0], win: results[1] };
+    });
+  }
+
   // ---- URL construction ----
 
-  function buildDownloadURL() {
+  function buildDownloadURL(platform) {
+    if (platform === 'windows') {
+      return CLOUDFRONT + '/latest-win';
+    }
     return CLOUDFRONT + '/latest';
   }
 
@@ -50,50 +67,44 @@
   function updateForPlatform(platform) {
     var btn = document.getElementById('download-btn');
     var note = document.getElementById('platform-note');
+    var effectivePlatform = (platform === 'unknown') ? 'macos' : platform;
 
-    if (platform === 'macos' || platform === 'unknown') {
+    if (effectivePlatform === 'macos') {
       btn.textContent = 'Download for macOS';
       btn.removeAttribute('aria-disabled');
-      // Restore download URL and version display from cache
-      if (cachedVersionInfo) {
-        updateVersionInfo(cachedVersionInfo);
-      } else {
-        btn.href = buildDownloadURL();
-      }
-      if (platform === 'unknown') {
-        note.textContent = 'Platform not detected. Showing macOS download.';
-      } else {
-        note.textContent = '';
-      }
+      btn.href = buildDownloadURL('macos');
+      var macInfo = cachedMacInfo || { version: null, sizeMB: null };
+      updateVersionDisplay(macInfo, 'macOS');
+      note.textContent = (platform === 'unknown')
+        ? 'Platform not detected. Showing macOS download.'
+        : '';
     } else {
-      btn.textContent = 'Windows \u2014 Coming Soon';
-      btn.setAttribute('aria-disabled', 'true');
-      btn.removeAttribute('href');
-      note.textContent = 'Windows support is coming soon. Stay tuned!';
-      document.getElementById('version-info').textContent = '';
+      btn.textContent = 'Download for Windows';
+      btn.removeAttribute('aria-disabled');
+      btn.href = buildDownloadURL('windows');
+      var winInfo = cachedWinInfo || { version: null, sizeMB: null };
+      updateVersionDisplay(winInfo, 'Windows');
+      note.textContent = '';
     }
   }
 
-  function updateVersionInfo(info) {
+  function updateVersionDisplay(info, platformLabel) {
     var btn = document.getElementById('download-btn');
     var versionEl = document.getElementById('version-info');
 
-    // Cache for platform switching
-    if (info.version) cachedVersionInfo = info;
-
-    // Set download URL regardless of version display
-    btn.href = buildDownloadURL();
     btn.setAttribute(
       'aria-label',
       'Download Prosponsive' +
         (info.version ? ' version ' + info.version : '') +
-        ' for macOS'
+        ' for ' + platformLabel
     );
 
     if (info.version) {
       var text = 'Version ' + info.version;
       if (info.sizeMB) text += ' \u2014 ' + info.sizeMB + ' MB';
       versionEl.textContent = text;
+    } else {
+      versionEl.textContent = '';
     }
   }
 
@@ -115,12 +126,10 @@
     updateForPlatform(platform);
     bindPlatformSwitches();
 
-    // Only fetch version info if macOS (or unknown, which defaults to macOS)
-    if (platform === 'macos' || platform === 'unknown') {
-      fetchVersionInfo().then(function (info) {
-        updateVersionInfo(info);
-      });
-    }
+    fetchAllVersionInfo().then(function () {
+      // Re-render with version data now available
+      updateForPlatform(platform);
+    });
   }
 
   if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- Download page now auto-detects visitor OS and shows the appropriate download button
- Windows visitors see "Download for Windows" linking to the EXE installer via CloudFront `/latest-win`
- Both macOS and Windows version info fetched in parallel from `latest-mac.yml` and `latest.yml`
- Platform switcher works for both platforms with live version and file size
- System requirements updated: macOS 12+ (arm64), Windows 10+ (x64/ARM64)
- Removed all "Coming Soon" text

## Changes
- `js/download.js` — dual-manifest fetching, platform-aware URL construction, enabled Windows button
- `index.html` — updated system requirements

## Test plan
- [ ] Open page in macOS browser — should show "Download for macOS" with version info
- [ ] Open page in Windows browser — should show "Download for Windows" with version info
- [ ] Click platform switcher buttons — both should update button, URL, and version display
- [ ] Verify download links resolve correctly (macOS → `/latest`, Windows → `/latest-win`)

References jb-brown/Prosponsive#267

🤖 Generated with [Claude Code](https://claude.com/claude-code)