### PR TITLE
Create standalone Feedback guide with Open Product / Closed Source philosophy

### DIFF
--- a/guides/SPEC-44-feedback-guide.md
+++ b/guides/SPEC-44-feedback-guide.md
@@ -1,0 +1,112 @@
+# SPEC-44: Standalone Feedback Guide with Open Product / Closed Source Philosophy
+
+## Summary
+
+Create `guides/feedback.html` — a new standalone guide with two parts: a philosophy section explaining Prosponsive's "Open Product, Closed Source" model, and a how-to section covering the built-in feedback system. Update existing guides to integrate it into the navigation sequence.
+
+## New File: `guides/feedback.html`
+
+### Structure
+
+1. **Cover page** — Same pattern as other guides (icon, title "Feedback & Philosophy", tagline)
+2. **Top nav bar** — Back: Email Assistant, Forward: Developer Guide
+3. **Section 1: Open Product, Closed Source** (philosophy)
+4. **Section 2: How to Give Feedback** (practical how-to, migrated from basics.html section 4)
+5. **Bottom nav bar** — Same as top
+6. **Footer** — Same pattern as other guides
+
+### Section 1 Key Messaging Points
+
+The philosophy section should cover these concepts in approachable prose (not bullet-point marketing copy):
+
+- **Open Product** means the product development process is transparent to users:
+  - Users can see engineering priorities (via "What are the current priorities?" in-app)
+  - Users submit feedback that directly shapes the roadmap
+  - Users can track what they've submitted and what's being worked on
+  - The product is built *with* its users, not just *for* them
+
+- **Closed Source** means the codebase is proprietary, but:
+  - This funds sustainable, full-time development
+  - Closed source does NOT mean opaque — the open product model ensures users have voice and visibility
+  - The built-in feedback system is the mechanism that makes this work — it's not a suggestion box, it's a direct line to engineering
+
+- **The balance**: Open Product + Closed Source = users get the transparency and influence of open source communities without requiring the codebase to be public. The feedback loop is the contract.
+
+### Section 2 Content (migrated from basics.html)
+
+Move the existing feedback how-to content from basics.html section 4, preserving:
+- How to report a bug (delegate to Prosponsive Support)
+- How to request a feature
+- How to check submission history
+- How to see current engineering priorities
+
+Expand slightly with:
+- A note that feedback goes directly to the engineering team (reinforcing the philosophy)
+- The fact that the Prosponsive Support agent handles the conversation naturally
+
+## Changes to Existing Files
+
+### `guides/basics.html`
+
+- **Replace section 4** ("Report a Bug or Request a Feature") with a short bridge paragraph and link:
+  - Keep the section heading (renumber if needed — it stays as section 4)
+  - Replace the detailed content with ~2 sentences explaining feedback exists and linking to the Feedback guide
+  - Preserve the Quick Reference table row for "Report a bug" (it's still useful as a quick ref)
+
+### `guides/user-guide.html`
+
+- **Insert a new guide card** between Email Assistant (3) and Developer Guide:
+  - Number: 4. Feedback & Philosophy
+  - Link: `feedback.html`
+  - Description: ~1 sentence about the open product model and how to use the feedback system
+- **Renumber** Developer Guide from 4 to 5
+
+### `guides/email-assistant-example.html`
+
+- **Bottom nav**: Change forward link from `n8n-workflow-developer-guide.html` / "Developer Guide" to `feedback.html` / "Feedback"
+
+### `guides/n8n-workflow-developer-guide.html`
+
+- **Top nav**: Change back link from `email-assistant-example.html` / "Email Assistant" to `feedback.html` / "Feedback"
+- **Bottom nav**: Same change
+
+### Navigation Sequence (final state)
+
+```
+Install Guide → Basics → Email Assistant → Feedback → Developer Guide
+```
+
+## Styling
+
+- Use identical CSS, class names, and HTML patterns from existing guides (copy from basics.html or email-assistant-example.html)
+- Same cover page SVG icon pattern
+- Same `.guide-nav`, `.tip`, `.section-number` classes
+- Same footer pattern
+
+## Footer Link Consolidation
+
+### `index.html` (lines 52-53)
+
+Replace the two separate links:
+```html
+<a href="https://github.com/jb-brown/Prosponsive/issues/new?template=bug_report.md">Report a Bug</a>
+<a href="https://github.com/jb-brown/Prosponsive/issues/new?template=feature_request.md">Request a Feature</a>
+```
+
+With a single link to the Feedback guide:
+```html
+<a href="guides/feedback.html">Feedback</a>
+```
+
+### `releases/index.html` (lines 147-148)
+
+Same consolidation — replace the two GitHub issue template links with:
+```html
+<a href="../guides/feedback.html">Feedback</a>
+```
+
+## Out of Scope
+
+- No changes to install-guide.html or n8n-tool-building-guide.html
+- No new CSS classes or design patterns
+- No changes to basics.html sections 1-3 or 5

--- a/guides/basics.html
+++ b/guides/basics.html
@@ -75,6 +75,10 @@
 
 <h1>Prosponsive Basics</h1>
 
+<div class="tip">
+  <strong>New:</strong> Looking for bug reports and feature requests? That content has moved to the <a href="feedback.html">Feedback &amp; Philosophy</a> guide.
+</div>
+
 <p>This guide introduces the Prosponsive interface, agents, and core features. If you haven't installed Prosponsive yet, start with the <a href="install-guide.html">Install Guide</a>.</p>
 
 <hr>
@@ -206,26 +210,11 @@
 
 <hr>
 
-<h2><span class="section-number">4.</span> Report a Bug or Request a Feature</h2>
+<h2><span class="section-number">4.</span> Feedback</h2>
 
-<p>Prosponsive has a built-in feedback system. If you find something that isn't working right or have an idea for improvement:</p>
+<p>Prosponsive has a built-in feedback system for reporting bugs and requesting features. Just tell Prosponsive what's on your mind — it delegates to the <strong>Prosponsive Support</strong> agent, which handles the rest.</p>
 
-<ol>
-  <li>In any channel, type:
-    <blockquote><p>I want to report a bug</p></blockquote>
-  </li>
-  <li>Prosponsive delegates to the <strong>Prosponsive Support</strong> agent.</li>
-  <li>The Support agent asks you to describe the issue — what happened, what you expected, and steps to reproduce.</li>
-  <li>Once it has enough detail, it submits a <strong>feedback</strong> tool card. Approve it to file the report.</li>
-</ol>
-
-<p>You can also:</p>
-
-<ul>
-  <li>Say "I'd like to request a feature" for feature requests.</li>
-  <li>Ask "What issues have I submitted?" to see your history.</li>
-  <li>Ask "What are the current engineering priorities?" to see what the team is focused on.</li>
-</ul>
+<p>For full details on how the feedback system works and the philosophy behind it, see the <a href="feedback.html">Feedback &amp; Philosophy</a> guide.</p>
 
 <hr>
 

--- a/guides/email-assistant-example.html
+++ b/guides/email-assistant-example.html
@@ -70,7 +70,7 @@
 
 <div class="guide-nav">
   <a href="basics.html">&larr; Prosponsive Basics</a>
-  <a href="n8n-workflow-developer-guide.html">Developer Guide &rarr;</a>
+  <a href="feedback.html">Feedback &rarr;</a>
 </div>
 
 <h1>Example: Email Assistant</h1>
@@ -368,7 +368,7 @@
 
 <div class="guide-nav">
   <a href="basics.html">&larr; Prosponsive Basics</a>
-  <a href="n8n-workflow-developer-guide.html">Developer Guide &rarr;</a>
+  <a href="feedback.html">Feedback &rarr;</a>
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -85,16 +85,6 @@
 
 <h2><span class="section-number">1.</span> Open Product, Closed Source</h2>
 
-<h3>The open-source promise is under pressure</h3>
-
-<p>Open-source projects are being inundated with AI-generated contributions -- pull requests, feature proposals, and code of wildly uneven quality. Every possible feature that could be dreamt up is being dreamt up, submitted, and left for maintainers to evaluate. The contributor groups that organize around these projects can't maintain quality or keep up with the volume. They tighten their acceptance criteria, slow down reviews, and eventually the core promise of open source -- that anyone can contribute and the project evolves with its community -- goes unfulfilled. The project atrophies not from lack of interest, but from too much of the wrong kind.</p>
-
-<h3>AI changes the equation for closed-source products too</h3>
-
-<p>On the product side, informed and managed AI agents can architect, build, and test user requests with a speed and consistency that wasn't possible before. Each feature request doesn't need as much human screening or manual contribution to reduce the funnel, reshape the ask, or validate the result. More gets done. The bottleneck shifts from "how many engineers can we hire" to "how well can we direct the work."</p>
-
-<p>Prosponsive is innovating on the software development process itself to leverage this seismic shift. We use AI agents internally -- not just to write code, but to triage issues, draft specifications, review changes, and enforce quality. This means your feedback doesn't sit in a queue waiting for a human to pick it up. It enters a development pipeline designed to act on it.</p>
-
 <h3>What "open product" means for you</h3>
 
 <p>As a Prosponsive user, you have direct access to the development process in ways that most software -- open or closed -- does not offer:</p>
@@ -113,6 +103,16 @@
 <h3>Why closed source?</h3>
 
 <p>Closed source funds the sustained development that makes all of this possible. It means a dedicated team working on Prosponsive full-time -- not a side project that depends on volunteer contributors. The trade-off is straightforward: the code stays private, but the product stays transparent. The feedback loop is the mechanism that makes this contract work.</p>
+
+<h3>The open-source promise is under pressure</h3>
+
+<p>Open-source projects are being inundated with AI-generated contributions -- pull requests, feature proposals, and code of wildly uneven quality. Every possible feature that could be dreamt up is being dreamt up, submitted, and left for maintainers to evaluate. The contributor groups that organize around these projects can't maintain quality or keep up with the volume. They tighten their acceptance criteria, slow down reviews, and eventually the core promise of open source -- that anyone can contribute and the project evolves with its community -- goes unfulfilled. The project atrophies not from lack of interest, but from too much of the wrong kind.</p>
+
+<h3>AI changes the equation for closed-source products too</h3>
+
+<p>On the product side, informed and managed AI agents can architect, build, and test user requests with a speed and consistency that wasn't possible before. Each feature request doesn't need as much human screening or manual contribution to reduce the funnel, reshape the ask, or validate the result. More gets done. The bottleneck shifts from "how many engineers can we hire" to "how well can we direct the work."</p>
+
+<p>Prosponsive is innovating on the software development process itself to leverage this seismic shift. We use AI agents internally -- not just to write code, but to triage issues, draft specifications, review changes, and enforce quality. This means your feedback doesn't sit in a queue waiting for a human to pick it up. It enters a development pipeline designed to act on it.</p>
 
 <hr>
 

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -79,11 +79,11 @@
 
 <p>Prosponsive is pioneering a new model of software development: <strong>Open Product, Closed Source</strong>. The short version: you have direct visibility into what we're building and direct influence over where it goes -- while the codebase stays proprietary to fund sustained, full-time development. Your feedback is the engine that makes this work, which is why we want you to understand the thinking behind it before we show you the buttons.</p>
 
+<p>This model is not just viable -- it's more valuable to both the people building the software and the people using it. AI is what makes that true.</p>
+
 <hr>
 
 <h2><span class="section-number">1.</span> Open Product, Closed Source</h2>
-
-<p>This model is not just viable -- it's more valuable to both the people building the software and the people using it. AI is what makes that true.</p>
 
 <h3>The open-source promise is under pressure</h3>
 

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -75,13 +75,15 @@
 
 <h1>Feedback &amp; Philosophy</h1>
 
-<p>Prosponsive is built on a simple idea: the people using the product should shape what it becomes. This guide explains how that works in practice and how to use the built-in feedback system to report bugs, request features, and see what the team is working on.</p>
+<p>Submitting feedback in Prosponsive isn't just filing a ticket. It's part of something larger.</p>
+
+<p>Prosponsive is pioneering a new model of software development that we call <strong>Open Product, Closed Source</strong>. The short version: you have direct visibility into what we're building and direct influence over where it goes -- while the codebase stays proprietary to fund sustained, full-time development. Your feedback is the engine that makes this work, which is why we want you to understand the thinking behind it before we show you the buttons.</p>
 
 <hr>
 
 <h2><span class="section-number">1.</span> Open Product, Closed Source</h2>
 
-<p>Open Product, Closed Source is not just a viable model -- it's a more valuable one, for both the people building the software and the people using it. AI is what makes that true.</p>
+<p>This model is not just viable -- it's more valuable to both the people building the software and the people using it. AI is what makes that true.</p>
 
 <h3>The open-source promise is under pressure</h3>
 

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -104,6 +104,10 @@
   <li><strong>The product is built with you, not just for you.</strong> User feedback directly shapes the roadmap. When multiple users report the same friction or request the same capability, it moves up in priority.</li>
 </ul>
 
+<h3>Toward just-in-time software delivery</h3>
+
+<p>The Prosponsive engineering team has a vision: just-in-time software delivery -- where the gap between a user's need and the working feature that meets it shrinks to nearly nothing. We're a long way from that today, but we work toward it every day. Every improvement to our AI-assisted development pipeline, every refinement to how feedback flows from users to working code, brings that vision closer. Your feedback isn't just heard -- it's fuel for a process that's actively getting faster.</p>
+
 <h3>Why closed source?</h3>
 
 <p>Closed source funds the sustained development that makes all of this possible. It means a dedicated team working on Prosponsive full-time -- not a side project that depends on volunteer contributors. The trade-off is straightforward: the code stays private, but the product stays transparent. The feedback loop is the mechanism that makes this contract work.</p>

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive — Feedback &amp; Philosophy</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">Feedback &amp; Philosophy</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="email-assistant-example.html">&larr; Email Assistant</a>
+  <a href="n8n-workflow-developer-guide.html">Developer Guide &rarr;</a>
+</div>
+
+<h1>Feedback &amp; Philosophy</h1>
+
+<p>Prosponsive is built on a simple idea: the people using the product should shape what it becomes. This guide explains how that works in practice and how to use the built-in feedback system to report bugs, request features, and see what the team is working on.</p>
+
+<hr>
+
+<h2><span class="section-number">1.</span> Open Product, Closed Source</h2>
+
+<p>Most software falls into two camps. Open-source projects give you the code but often lack the resources for sustained, full-time development. Proprietary products have the resources but keep everything behind closed doors -- you submit a ticket and hope for the best.</p>
+
+<p>Prosponsive takes a different path. The codebase is proprietary, which funds full-time development and ensures the product can grow sustainably. But the product development process itself is open to every user.</p>
+
+<h3>What "open product" means for you</h3>
+
+<p>As a Prosponsive user, you have direct access to the development process in ways that most proprietary software does not offer:</p>
+
+<ul>
+  <li><strong>You can see what the team is building.</strong> Ask Prosponsive "What are the current engineering priorities?" and the Support agent will show you what's actively being worked on and what's coming next.</li>
+  <li><strong>Your feedback goes straight to engineering.</strong> Bug reports and feature requests submitted through Prosponsive land directly on the engineering board -- not in a support queue, not in a suggestion box. Every submission is reviewed by the people building the product.</li>
+  <li><strong>You can track what you've submitted.</strong> Ask "What issues have I submitted?" to see the status of your reports and requests. You're never left wondering whether anyone read your feedback.</li>
+  <li><strong>The product is built with you, not just for you.</strong> User feedback directly shapes the roadmap. When multiple users report the same friction or request the same capability, it moves up in priority.</li>
+</ul>
+
+<h3>Why closed source?</h3>
+
+<p>Closed source funds the sustained development that makes all of this possible. It means a dedicated team working on Prosponsive full-time -- not a side project that depends on volunteer contributors. The trade-off is straightforward: the code stays private, but the product stays transparent. The feedback loop is the mechanism that makes this contract work.</p>
+
+<hr>
+
+<h2><span class="section-number">2.</span> How to Give Feedback</h2>
+
+<p>Prosponsive has a built-in feedback system powered by the <strong>Prosponsive Support</strong> agent. You don't need to leave the app, open a browser, or file a ticket somewhere else. Just talk to Prosponsive.</p>
+
+<h3>Report a bug</h3>
+
+<p>If something isn't working the way you expect, tell Prosponsive:</p>
+
+<blockquote><p>I want to report a bug</p></blockquote>
+
+<p>Prosponsive delegates to the <strong>Prosponsive Support</strong> agent, which will ask you to describe what happened, what you expected, and any steps to reproduce the issue. Once it has enough detail, it submits a <strong>feedback</strong> tool card. Approve it to file the report.</p>
+
+<p>Your bug report lands directly on the engineering board. No intermediaries, no support tiers.</p>
+
+<h3>Request a feature</h3>
+
+<p>Have an idea for something Prosponsive should do? Say:</p>
+
+<blockquote><p>I'd like to request a feature</p></blockquote>
+
+<p>The Support agent walks you through describing the feature -- what you want, why it matters, and how you'd use it. Same process: it composes a feedback submission, you approve the tool card, and the request goes to engineering.</p>
+
+<h3>Check your submission history</h3>
+
+<p>Want to see what you've already reported or requested? Ask:</p>
+
+<blockquote><p>What issues have I submitted?</p></blockquote>
+
+<p>The Support agent retrieves your submissions and shows their current status.</p>
+
+<h3>See current engineering priorities</h3>
+
+<p>Curious about what the team is focused on? Ask:</p>
+
+<blockquote><p>What are the current engineering priorities?</p></blockquote>
+
+<p>This is the "open product" in action -- you can see the team's focus areas and how your feedback fits into the bigger picture.</p>
+
+<div class="tip">
+  <strong>Tip:</strong> You don't need to use these exact phrases. The Prosponsive agent understands natural language, so "something's broken" or "I have an idea" will work just as well. Prosponsive will delegate to the Support agent when it recognizes a feedback conversation.
+</div>
+
+<hr>
+
+<div class="guide-nav">
+  <a href="email-assistant-example.html">&larr; Email Assistant</a>
+  <a href="n8n-workflow-developer-guide.html">Developer Guide &rarr;</a>
+</div>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> &mdash; Lead more. Manage less.
+</div>
+
+</body>
+</html>

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -77,7 +77,7 @@
 
 <p>Submitting feedback in Prosponsive isn't just filing a ticket. It's part of something larger.</p>
 
-<p>Prosponsive is pioneering a new model of software development that we call <strong>Open Product, Closed Source</strong>. The short version: you have direct visibility into what we're building and direct influence over where it goes -- while the codebase stays proprietary to fund sustained, full-time development. Your feedback is the engine that makes this work, which is why we want you to understand the thinking behind it before we show you the buttons.</p>
+<p>Prosponsive is pioneering a new model of software development: <strong>Open Product, Closed Source</strong>. The short version: you have direct visibility into what we're building and direct influence over where it goes -- while the codebase stays proprietary to fund sustained, full-time development. Your feedback is the engine that makes this work, which is why we want you to understand the thinking behind it before we show you the buttons.</p>
 
 <hr>
 

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -81,17 +81,25 @@
 
 <h2><span class="section-number">1.</span> Open Product, Closed Source</h2>
 
-<p>Most software falls into two camps. Open-source projects give you the code but often lack the resources for sustained, full-time development. Proprietary products have the resources but keep everything behind closed doors -- you submit a ticket and hope for the best.</p>
+<p>Open Product, Closed Source is not just a viable model -- it's a more valuable one, for both the people building the software and the people using it. AI is what makes that true.</p>
 
-<p>Prosponsive takes a different path. The codebase is proprietary, which funds full-time development and ensures the product can grow sustainably. But the product development process itself is open to every user.</p>
+<h3>The open-source promise is under pressure</h3>
+
+<p>Open-source projects are being inundated with AI-generated contributions -- pull requests, feature proposals, and code of wildly uneven quality. Every possible feature that could be dreamt up is being dreamt up, submitted, and left for maintainers to evaluate. The contributor groups that organize around these projects can't maintain quality or keep up with the volume. They tighten their acceptance criteria, slow down reviews, and eventually the core promise of open source -- that anyone can contribute and the project evolves with its community -- goes unfulfilled. The project atrophies not from lack of interest, but from too much of the wrong kind.</p>
+
+<h3>AI changes the equation for closed-source products too</h3>
+
+<p>On the product side, informed and managed AI agents can architect, build, and test user requests with a speed and consistency that wasn't possible before. Each feature request doesn't need as much human screening or manual contribution to reduce the funnel, reshape the ask, or validate the result. More gets done. The bottleneck shifts from "how many engineers can we hire" to "how well can we direct the work."</p>
+
+<p>Prosponsive is innovating on the software development process itself to leverage this seismic shift. We use AI agents internally -- not just to write code, but to triage issues, draft specifications, review changes, and enforce quality. This means your feedback doesn't sit in a queue waiting for a human to pick it up. It enters a development pipeline designed to act on it.</p>
 
 <h3>What "open product" means for you</h3>
 
-<p>As a Prosponsive user, you have direct access to the development process in ways that most proprietary software does not offer:</p>
+<p>As a Prosponsive user, you have direct access to the development process in ways that most software -- open or closed -- does not offer:</p>
 
 <ul>
   <li><strong>You can see what the team is building.</strong> Ask Prosponsive "What are the current engineering priorities?" and the Support agent will show you what's actively being worked on and what's coming next.</li>
-  <li><strong>Your feedback goes straight to engineering.</strong> Bug reports and feature requests submitted through Prosponsive land directly on the engineering board -- not in a support queue, not in a suggestion box. Every submission is reviewed by the people building the product.</li>
+  <li><strong>Your feedback goes straight to engineering.</strong> Bug reports and feature requests submitted through Prosponsive land directly on the engineering board -- not in a support queue, not in a suggestion box. Every submission is reviewed and triaged by the people and agents building the product.</li>
   <li><strong>You can track what you've submitted.</strong> Ask "What issues have I submitted?" to see the status of your reports and requests. You're never left wondering whether anyone read your feedback.</li>
   <li><strong>The product is built with you, not just for you.</strong> User feedback directly shapes the roadmap. When multiple users report the same friction or request the same capability, it moves up in priority.</li>
 </ul>

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -69,7 +69,7 @@
 </div>
 
 <div class="guide-nav">
-  <a href="email-assistant-example.html">&larr; Email Assistant</a>
+  <a href="feedback.html">&larr; Feedback</a>
   <span></span>
 </div>
 
@@ -432,7 +432,7 @@ POST /api/ai/agent-inference
 <hr>
 
 <div class="guide-nav">
-  <a href="email-assistant-example.html">&larr; Email Assistant</a>
+  <a href="feedback.html">&larr; Feedback</a>
   <span></span>
 </div>
 

--- a/guides/user-guide.html
+++ b/guides/user-guide.html
@@ -88,7 +88,12 @@
 </div>
 
 <div class="guide-card">
-  <h3><span class="section-number">4.</span> <a href="n8n-workflow-developer-guide.html">Developer Guide</a></h3>
+  <h3><span class="section-number">4.</span> <a href="feedback.html">Feedback &amp; Philosophy</a></h3>
+  <p>Learn about Prosponsive's open product model and how to use the built-in feedback system to report bugs, request features, and see engineering priorities.</p>
+</div>
+
+<div class="guide-card">
+  <h3><span class="section-number">5.</span> <a href="n8n-workflow-developer-guide.html">Developer Guide</a></h3>
   <p>Build custom n8n tools and workflows to extend Prosponsive's capabilities.</p>
 </div>
 

--- a/index.html
+++ b/index.html
@@ -49,8 +49,7 @@
     <p>&copy; 2026 Prosponsive. All rights reserved.</p>
     <nav aria-label="Footer links">
       <a href="releases/">Release Notes</a>
-      <a href="https://github.com/jb-brown/Prosponsive/issues/new?template=bug_report.md">Report a Bug</a>
-      <a href="https://github.com/jb-brown/Prosponsive/issues/new?template=feature_request.md">Request a Feature</a>
+      <a href="guides/feedback.html">Feedback</a>
     </nav>
   </footer>
 

--- a/releases/index.html
+++ b/releases/index.html
@@ -144,8 +144,7 @@
     <p>&copy; 2026 Prosponsive. All rights reserved.</p>
     <nav aria-label="Footer links">
       <a href="../">Download</a>
-      <a href="https://github.com/jb-brown/Prosponsive/issues/new?template=bug_report.md">Report a Bug</a>
-      <a href="https://github.com/jb-brown/Prosponsive/issues/new?template=feature_request.md">Request a Feature</a>
+      <a href="../guides/feedback.html">Feedback</a>
     </nav>
   </footer>
 </body>


### PR DESCRIPTION
## Summary

- Creates `guides/feedback.html` -- a new standalone guide with two sections: the "Open Product, Closed Source" philosophy and a practical how-to for the built-in feedback system
- Replaces basics.html section 4 with a brief mention and link to the new guide
- Inserts Feedback as guide #4 on the user-guide landing page, renumbers Developer Guide to #5
- Updates sequential navigation across all guides: Install Guide > Basics > Email Assistant > Feedback > Developer Guide
- Consolidates the "Report a Bug" and "Request a Feature" footer links on `index.html` and `releases/index.html` into a single "Feedback" link pointing to the new guide

## Test plan

- [ ] Open `guides/feedback.html` in a browser and verify cover page, sections 1-2, and nav links render correctly
- [ ] Verify `guides/basics.html` section 4 now shows brief text + link to Feedback guide
- [ ] Verify `guides/user-guide.html` shows 5 guide cards in correct order with Feedback at position 4
- [ ] Click through all sequential nav links (forward and back) across all 5 guides to confirm the chain is unbroken
- [ ] Verify `index.html` footer has a single "Feedback" link (no more Report a Bug / Request a Feature)
- [ ] Verify `releases/index.html` footer has a single "Feedback" link with correct relative path

closes #44

Generated with [Claude Code](https://claude.com/claude-code)