### PR TITLE
docs: add competitive comparison guides

### DIFF
--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -110,6 +110,16 @@
   <p>Cloud-hosted agents versus local agents with real tools. If you want agents that access your files, run workflows, and keep your data on your machine, read this guide.</p>
 </div>
 
+<div class="compare-card">
+  <h3><a href="vs-openclaw.html">Prosponsive vs. OpenClaw</a></h3>
+  <p>Two local-first AI assistants with very different security architectures. OpenClaw offers broad system access with documented security incidents. Prosponsive offers credential isolation and defined tool boundaries by design.</p>
+</div>
+
+<div class="compare-card">
+  <h3><a href="vs-claude-cowork.html">Prosponsive vs. Claude Cowork</a></h3>
+  <p>Anthropic's autonomous desktop agent for knowledge workers versus Prosponsive's always-on productivity platform. Similar audiences, fundamentally different architectures.</p>
+</div>
+
 <hr>
 
 <h2>At a Glance</h2>
@@ -122,6 +132,8 @@
     <th>Automation</th>
     <th>Local Models</th>
     <th>Custom Agents</th>
+    <th>OpenClaw</th>
+    <th>Claude Cowork</th>
     <th>Prosponsive</th>
   </tr>
   <tr>
@@ -131,6 +143,8 @@
     <td>Varies</td>
     <td>Yes</td>
     <td>No</td>
+    <td>Yes</td>
+    <td>Yes</td>
     <td><strong>Yes</strong></td>
   </tr>
   <tr>
@@ -139,6 +153,8 @@
     <td>No</td>
     <td>N/A</td>
     <td>Local only</td>
+    <td>No</td>
+    <td>Yes</td>
     <td>No</td>
     <td><strong>Yes</strong></td>
   </tr>
@@ -150,6 +166,8 @@
     <td>No</td>
     <td>Limited</td>
     <td><strong>Yes</strong></td>
+    <td>Dev tools</td>
+    <td><strong>Yes</strong></td>
   </tr>
   <tr>
     <td>Works offline</td>
@@ -158,6 +176,8 @@
     <td>No</td>
     <td>Yes</td>
     <td>No</td>
+    <td>No</td>
+    <td>No</td>
     <td><strong>With local models</strong></td>
   </tr>
   <tr>
@@ -165,6 +185,8 @@
     <td>No</td>
     <td>No</td>
     <td>Varies</td>
+    <td>Yes</td>
+    <td>No</td>
     <td>Yes</td>
     <td>No</td>
     <td><strong>Yes</strong></td>
@@ -176,6 +198,8 @@
     <td><strong>Yes</strong></td>
     <td>No</td>
     <td>No</td>
+    <td>No</td>
+    <td>No</td>
     <td><strong>Yes</strong></td>
   </tr>
   <tr>
@@ -185,6 +209,8 @@
     <td>Varies</td>
     <td>N/A</td>
     <td>No</td>
+    <td>No</td>
+    <td>N/A</td>
     <td><strong>Yes</strong></td>
   </tr>
 </table>

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -96,8 +96,8 @@
 </div>
 
 <div class="compare-card">
-  <h3><a href="vs-automation.html">Prosponsive vs. n8n, Zapier, and Make</a></h3>
-  <p>Standalone automation platforms versus AI-integrated automation. Prosponsive bundles n8n inside an AI assistant — this guide explains why that combination is more than the sum of its parts.</p>
+  <h3><a href="vs-automation.html">Prosponsive vs. Zapier and Make</a></h3>
+  <p>Standalone automation platforms versus AI-driven automation. Prosponsive leverages n8n as its tool layer — this guide explains why AI agents with visual workflow tools are more than trigger-action automations.</p>
 </div>
 
 <div class="compare-card">

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -1,0 +1,200 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive Comparisons</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  .compare-card { border: 1px solid #D6DBD7; border-left: 4px solid #2F4F3E; border-radius: 0 4px 4px 0; padding: 1em 1.2em; margin: 1em 0; }
+  .compare-card h3 { margin-top: 0; }
+  .compare-card p { margin: 0.4em 0; color: #5C635F; font-size: 0.95em; }
+  .compare-card a { font-weight: 500; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">Comparison Guides</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="../basics.html">&larr; Prosponsive Basics</a>
+  <span></span>
+</div>
+
+<h1>How Prosponsive Compares</h1>
+
+<p>Prosponsive occupies a unique position in the AI tooling landscape. It combines a local-first AI assistant with real tool integration, provider flexibility, and full data privacy — a combination that no single competitor offers today.</p>
+
+<p>These guides provide honest, side-by-side comparisons to help you decide whether Prosponsive is the right fit for your workflow. Each guide acknowledges competitor strengths and focuses on genuine architectural differences rather than marketing claims.</p>
+
+<hr>
+
+<div class="compare-card">
+  <h3><a href="vs-cloud-chat.html">Prosponsive vs. ChatGPT, Claude.ai, and Gemini</a></h3>
+  <p>Cloud-only AI chat versus a local-first assistant with real tool integration. If you need more than conversation — file access, workflow automation, data privacy — this comparison explains the tradeoffs.</p>
+</div>
+
+<div class="compare-card">
+  <h3><a href="vs-copilot-workspace.html">Prosponsive vs. Microsoft Copilot and Google Workspace AI</a></h3>
+  <p>Suite-embedded AI versus a provider-agnostic platform. If vendor lock-in, model choice, or cross-suite flexibility matters to you, start here.</p>
+</div>
+
+<div class="compare-card">
+  <h3><a href="vs-automation.html">Prosponsive vs. n8n, Zapier, and Make</a></h3>
+  <p>Standalone automation platforms versus AI-integrated automation. Prosponsive bundles n8n inside an AI assistant — this guide explains why that combination is more than the sum of its parts.</p>
+</div>
+
+<div class="compare-card">
+  <h3><a href="vs-local-models.html">Prosponsive vs. Ollama, LM Studio, and GPT4All</a></h3>
+  <p>Raw local model runners versus a full productivity platform. If you want local AI that actually does things — not just generates text — this comparison is for you.</p>
+</div>
+
+<div class="compare-card">
+  <h3><a href="vs-custom-agents.html">Prosponsive vs. Custom GPTs and OpenAI Assistants</a></h3>
+  <p>Cloud-hosted agents versus local agents with real tools. If you want agents that access your files, run workflows, and keep your data on your machine, read this guide.</p>
+</div>
+
+<hr>
+
+<h2>At a Glance</h2>
+
+<table>
+  <tr>
+    <th>Capability</th>
+    <th>Cloud Chat</th>
+    <th>Suite AI</th>
+    <th>Automation</th>
+    <th>Local Models</th>
+    <th>Custom Agents</th>
+    <th>Prosponsive</th>
+  </tr>
+  <tr>
+    <td>Data stays on your machine</td>
+    <td>No</td>
+    <td>No</td>
+    <td>Varies</td>
+    <td>Yes</td>
+    <td>No</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Choose any AI provider</td>
+    <td>No</td>
+    <td>No</td>
+    <td>N/A</td>
+    <td>Local only</td>
+    <td>No</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Real tool integration</td>
+    <td>Limited</td>
+    <td>Suite only</td>
+    <td><strong>Yes</strong></td>
+    <td>No</td>
+    <td>Limited</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Works offline</td>
+    <td>No</td>
+    <td>No</td>
+    <td>No</td>
+    <td>Yes</td>
+    <td>No</td>
+    <td><strong>With local models</strong></td>
+  </tr>
+  <tr>
+    <td>No vendor lock-in</td>
+    <td>No</td>
+    <td>No</td>
+    <td>Varies</td>
+    <td>Yes</td>
+    <td>No</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Visual workflow builder</td>
+    <td>No</td>
+    <td>No</td>
+    <td><strong>Yes</strong></td>
+    <td>No</td>
+    <td>No</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Credential isolation</td>
+    <td>N/A</td>
+    <td>N/A</td>
+    <td>Varies</td>
+    <td>N/A</td>
+    <td>No</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+</table>
+
+<hr>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> — Lead more. Manage less.
+</div>
+
+</body>
+</html>

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -86,6 +86,16 @@
 <hr>
 
 <div class="compare-card">
+  <h3><a href="vs-openclaw.html">Prosponsive vs. OpenClaw</a></h3>
+  <p>Two local-first AI assistants with very different security architectures. OpenClaw offers broad system access with documented security incidents. Prosponsive offers credential isolation and defined tool boundaries by design.</p>
+</div>
+
+<div class="compare-card">
+  <h3><a href="vs-claude-cowork.html">Prosponsive vs. Claude Cowork</a></h3>
+  <p>Anthropic's autonomous desktop agent for knowledge workers versus Prosponsive's always-on productivity platform. Similar audiences, fundamentally different architectures.</p>
+</div>
+
+<div class="compare-card">
   <h3><a href="vs-cloud-chat.html">Prosponsive vs. ChatGPT, Claude.ai, and Gemini</a></h3>
   <p>Cloud-only AI chat versus a local-first assistant with real tool integration. If you need more than conversation — file access, workflow automation, data privacy — this comparison explains the tradeoffs.</p>
 </div>
@@ -108,16 +118,6 @@
 <div class="compare-card">
   <h3><a href="vs-custom-agents.html">Prosponsive vs. Custom GPTs and OpenAI Assistants</a></h3>
   <p>Cloud-hosted agents versus local agents with real tools. If you want agents that access your files, run workflows, and keep your data on your machine, read this guide.</p>
-</div>
-
-<div class="compare-card">
-  <h3><a href="vs-openclaw.html">Prosponsive vs. OpenClaw</a></h3>
-  <p>Two local-first AI assistants with very different security architectures. OpenClaw offers broad system access with documented security incidents. Prosponsive offers credential isolation and defined tool boundaries by design.</p>
-</div>
-
-<div class="compare-card">
-  <h3><a href="vs-claude-cowork.html">Prosponsive vs. Claude Cowork</a></h3>
-  <p>Anthropic's autonomous desktop agent for knowledge workers versus Prosponsive's always-on productivity platform. Similar audiences, fundamentally different architectures.</p>
 </div>
 
 <hr>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive vs. n8n, Zapier, and Make</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">vs. n8n, Zapier, and Make</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="vs-copilot-workspace.html">&larr; vs. Copilot &amp; Workspace AI</a>
+  <a href="vs-local-models.html">vs. Local Model Runners &rarr;</a>
+</div>
+
+<h1>Prosponsive vs. n8n, Zapier, and Make</h1>
+
+<p>n8n, Zapier, and Make are workflow automation platforms. They let you connect services, move data between systems, and automate repetitive tasks — often without writing code. They are excellent at what they do, and millions of workflows run on them every day.</p>
+
+<p>Prosponsive is not an automation platform. It is an AI assistant that happens to include one. Prosponsive bundles a local instance of n8n as its tool layer, which means it shares DNA with n8n but serves a fundamentally different purpose. This guide explains the relationship and the differences.</p>
+
+<hr>
+
+<h2><span class="section-number">1.</span> What Automation Platforms Do Well</h2>
+
+<ul>
+  <li><strong>Visual workflow building.</strong> Drag-and-drop interfaces that make complex integrations accessible to non-developers. Zapier's simplicity is legendary; Make's visual flows are powerful; n8n combines both with code-level extensibility.</li>
+  <li><strong>Massive integration libraries.</strong> Zapier connects to 6,000+ apps. Make and n8n each support hundreds of built-in integrations. Pre-built templates mean you can automate common patterns in minutes.</li>
+  <li><strong>Reliable scheduling.</strong> Cron-based triggers, webhook listeners, event-driven execution. These platforms are built to run workflows reliably, at scale, 24/7.</li>
+  <li><strong>Team collaboration.</strong> Shared workspaces, version history, and access controls for managing workflows across teams.</li>
+  <li><strong>Battle-tested in production.</strong> Zapier and Make run billions of tasks per month. Their infrastructure is built for reliability and scale in ways that individual deployments cannot match.</li>
+</ul>
+
+<hr>
+
+<h2><span class="section-number">2.</span> Where Prosponsive Differs</h2>
+
+<h3>AI-driven, not trigger-driven</h3>
+
+<p>Automation platforms execute workflows based on triggers — a new email arrives, a form is submitted, a schedule fires. The workflow logic is fixed: if X happens, do Y.</p>
+
+<p>Prosponsive adds an AI layer on top. Instead of defining every condition and branch in advance, you describe what you want in natural language. The AI decides which tools to use, in what order, and how to handle edge cases. You can still build structured n8n workflows for predictable tasks, but you can also let the AI compose tool calls dynamically based on context.</p>
+
+<h3>Prosponsive uses n8n — it does not replace it</h3>
+
+<p>This is a critical distinction. Prosponsive bundles a local n8n instance and uses it as its tool layer. Every tool your Prosponsive agent calls is an n8n workflow running on your machine. This means:</p>
+
+<ul>
+  <li>You get n8n's full workflow builder, its integration library, and its visual debugging tools</li>
+  <li>Workflows you build in n8n are directly available to your AI agent</li>
+  <li>You can inspect exactly what your agent does — every workflow execution is visible in n8n's interface</li>
+  <li>The AI agent interacts through n8n's API, never through credentials directly</li>
+</ul>
+
+<p>If you already use and love n8n, Prosponsive adds an AI conversation layer on top. If you are new to n8n, you get it bundled and managed automatically.</p>
+
+<h3>Credential isolation</h3>
+
+<p>In standalone automation platforms, credentials are stored within the platform and used directly by workflow executions. The platform has access to your credentials by design.</p>
+
+<p>In Prosponsive, credentials are stored in n8n's encrypted vault. The AI agent never sees them. When the agent calls a tool, it triggers a workflow execution through n8n's API — the credentials are resolved by n8n at runtime. This architecture means that even if the AI model were compromised or misbehaved, it could not extract your credentials.</p>
+
+<h3>Local-first execution</h3>
+
+<p>Zapier and Make run entirely in the cloud. Your workflow definitions, credentials, and execution data live on their servers. n8n offers both cloud and self-hosted options.</p>
+
+<p>Prosponsive runs n8n locally on your machine. Workflow definitions, credentials, execution logs, and data stay on your computer. There is no cloud service to depend on, no data to transmit, and no subscription for workflow executions.</p>
+
+<hr>
+
+<h2><span class="section-number">3.</span> Side-by-Side Comparison</h2>
+
+<table>
+  <tr>
+    <th>Factor</th>
+    <th>Zapier / Make</th>
+    <th>n8n (standalone)</th>
+    <th>Prosponsive (with n8n)</th>
+  </tr>
+  <tr>
+    <td>AI-driven tool use</td>
+    <td>No (trigger-based)</td>
+    <td>No (trigger-based)</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Visual workflow builder</td>
+    <td><strong>Yes</strong></td>
+    <td><strong>Yes</strong></td>
+    <td><strong>Yes</strong> (via n8n)</td>
+  </tr>
+  <tr>
+    <td>Integration count</td>
+    <td>6,000+ (Zapier)</td>
+    <td>400+</td>
+    <td>400+ (via n8n)</td>
+  </tr>
+  <tr>
+    <td>Data residency</td>
+    <td>Cloud</td>
+    <td>Self-hosted or cloud</td>
+    <td>Your machine</td>
+  </tr>
+  <tr>
+    <td>Credential handling</td>
+    <td>Platform access</td>
+    <td>Platform access</td>
+    <td><strong>Isolated from AI</strong></td>
+  </tr>
+  <tr>
+    <td>Natural language interface</td>
+    <td>Limited (AI features)</td>
+    <td>No</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Scaling</td>
+    <td><strong>Cloud-scale</strong></td>
+    <td>Self-managed</td>
+    <td>Single machine</td>
+  </tr>
+  <tr>
+    <td>Cost</td>
+    <td>Per-task pricing</td>
+    <td>Free (self-hosted)</td>
+    <td>Free + AI API costs</td>
+  </tr>
+</table>
+
+<hr>
+
+<h2><span class="section-number">4.</span> Key Decision Factors</h2>
+
+<h3>Privacy</h3>
+
+<p>Cloud automation platforms process your data — including credentials — on remote infrastructure. For workflows that handle sensitive data (customer PII, financial records, internal communications), this means trusting the platform with that data. Prosponsive keeps everything local, and credentials are isolated from the AI layer entirely.</p>
+
+<h3>Cost</h3>
+
+<p>Zapier's pricing scales with task volume — the free tier is limited, and business plans can cost hundreds of dollars per month. Make is more affordable but still per-execution. Prosponsive bundles n8n locally at no cost for workflow execution. Your only variable cost is AI API usage.</p>
+
+<h3>Extensibility</h3>
+
+<p>Zapier has the largest integration library but limited customization per integration. Make offers more complex logic but within its visual paradigm. n8n (and therefore Prosponsive) offers full code-level extensibility — you can write JavaScript or Python within workflow nodes, call arbitrary HTTP endpoints, and build completely custom integrations.</p>
+
+<h3>Scale</h3>
+
+<p>This is where standalone automation platforms have a clear advantage. Zapier and Make are built for scale — millions of executions, high availability, distributed infrastructure. Prosponsive runs on a single machine. If you need to process thousands of webhook events per minute or run workflows that must be highly available, a cloud automation platform is the right choice.</p>
+
+<hr>
+
+<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+
+<h3>Standalone automation platforms are better if you:</h3>
+
+<ul>
+  <li>Need high-volume, scheduled, or event-driven automation</li>
+  <li>Want cloud-scale reliability and uptime guarantees</li>
+  <li>Primarily need trigger-based workflows, not AI-driven tasks</li>
+  <li>Need team collaboration on workflow definitions</li>
+  <li>Want the largest possible library of pre-built integrations (Zapier)</li>
+</ul>
+
+<h3>Prosponsive is the better choice if you:</h3>
+
+<ul>
+  <li>Want AI to decide which tools to use based on natural language requests</li>
+  <li>Need credential isolation — the AI should never see your passwords and API keys</li>
+  <li>Want workflows and data to stay on your machine</li>
+  <li>Are building personal productivity automation, not enterprise-scale pipelines</li>
+  <li>Want the power of n8n with an AI conversation layer on top</li>
+</ul>
+
+<blockquote>
+  <p><strong>Prosponsive complements, not competes.</strong> Prosponsive uses n8n internally. If you already run n8n (cloud or self-hosted) for production automation, Prosponsive adds an AI-powered personal assistant that happens to use the same workflow engine. Your production n8n and your Prosponsive n8n are separate instances with separate data.</p>
+</blockquote>
+
+<hr>
+
+<div class="guide-nav">
+  <a href="vs-copilot-workspace.html">&larr; vs. Copilot &amp; Workspace AI</a>
+  <a href="vs-local-models.html">vs. Local Model Runners &rarr;</a>
+</div>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> — Lead more. Manage less.
+</div>
+
+</body>
+</html>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -101,6 +101,12 @@
 
 <p>Prosponsive adds an AI layer on top. Instead of defining every condition and branch in advance, you describe what you want in natural language. The AI decides which tools to use, in what order, and how to handle edge cases. You can still build structured n8n workflows for predictable tasks, but you can also let the AI compose tool calls dynamically based on context. That AI layer supports 7+ providers with automatic failover — you define a priority list of providers and models, and if one goes down or you hit a rate limit, Prosponsive switches to the next one without interruption. For more detail, see <a href="../features.html">Tools and Workflows</a> in the Feature Guide.</p>
 
+<h3>Workflow results drive continued work</h3>
+
+<p>In Zapier and Make, a completed workflow is a "done" notification sitting in a log that you only see when you're logged into that platform's interface. The result doesn't go anywhere — it's an endpoint.</p>
+
+<p>In Prosponsive, a completed workflow is an input. The result flows back to your AI agent, which uses it to decide what to do next — take another action, update a different system, notify you, or continue a multi-step task. Workflows are not standalone automations that terminate. They are tools in your agent's hands, and their outputs contribute to the continued execution of your work.</p>
+
 <h3>Powered by n8n — the best workflow engine available</h3>
 
 <p>Prosponsive leverages a local <a href="https://n8n.io">n8n</a> instance as its tool layer and helps you set it up and manage it. Every tool your agent calls is an n8n workflow. You get n8n's full visual workflow builder, its integration library, and its debugging tools. Workflows you build are directly available to your AI agents, and every execution is visible and inspectable.</p>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -188,7 +188,7 @@
 
 <h3>Scale</h3>
 
-<p>This is where standalone automation platforms have a clear advantage. Zapier and Make are built for scale — millions of executions, high availability, distributed infrastructure. Prosponsive runs on a single machine. If you need to process thousands of webhook events per minute or run workflows that must be highly available, a cloud automation platform is the right choice.</p>
+<p>Zapier and Make are built for high-volume scale — millions of executions, high availability, distributed infrastructure. When you need that level of scale without requiring internal system access, private data, or AI agent judgement, they may be the right choice for that specific task. Connecting them as a Prosponsive tool for your greater personal workflow value would give you the best of both — cloud scale where it makes sense, local AI-driven orchestration everywhere else.</p>
 
 <hr>
 

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -209,19 +209,17 @@
 
 <hr>
 
-<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+<h2><span class="section-number">5.</span> Making the Choice</h2>
 
-<h3>Standalone automation platforms are better if you:</h3>
+<h3>n8n, Zapier, or Make may be enough if you:</h3>
 
 <ul>
-  <li>Need high-volume, scheduled, or event-driven automation</li>
-  <li>Want cloud-scale reliability and uptime guarantees</li>
-  <li>Primarily need trigger-based workflows, not AI-driven tasks</li>
-  <li>Need team collaboration on workflow definitions</li>
-  <li>Want the largest possible library of pre-built integrations (Zapier)</li>
+  <li>Only need trigger-action automations without AI reasoning</li>
+  <li>Are comfortable building and monitoring workflows yourself</li>
+  <li>Don't need an AI agent to decide when and how to use your automations</li>
 </ul>
 
-<h3>Prosponsive is the better choice if you:</h3>
+<h3>Choose Prosponsive when you need more:</h3>
 
 <ul>
   <li>Want AI to decide which tools to use based on natural language requests</li>
@@ -230,10 +228,6 @@
   <li>Are building personal productivity automation, not enterprise-scale pipelines</li>
   <li>Want the power of n8n with an AI conversation layer on top</li>
 </ul>
-
-<blockquote>
-  <p><strong>Prosponsive complements, not competes.</strong> Prosponsive uses n8n internally. If you already run n8n (cloud or self-hosted) for production automation, Prosponsive adds an AI-powered personal assistant that happens to use the same workflow engine. Your production n8n and your Prosponsive n8n are separate instances with separate data.</p>
-</blockquote>
 
 <hr>
 

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Prosponsive vs. n8n, Zapier, and Make</title>
+  <title>Prosponsive vs. Zapier and Make</title>
   <style>
   @page {
     margin: 0.75in 1in;
@@ -64,7 +64,7 @@
     </svg>
   </div>
   <h1>Prosponsive</h1>
-  <div class="tagline">vs. n8n, Zapier, and Make</div>
+  <div class="tagline">vs. Zapier and Make</div>
   <div class="version">Lead more. Manage less.</div>
 </div>
 
@@ -73,19 +73,19 @@
   <a href="vs-local-models.html">vs. Local Model Runners &rarr;</a>
 </div>
 
-<h1>Prosponsive vs. n8n, Zapier, and Make</h1>
+<h1>Prosponsive vs. Zapier and Make</h1>
 
-<p>n8n, Zapier, and Make are workflow automation platforms. They let you connect services, move data between systems, and automate repetitive tasks — often without writing code. They are excellent at what they do, and millions of workflows run on them every day.</p>
+<p>Zapier and Make are workflow automation platforms. They let you connect services, move data between systems, and automate repetitive tasks — often without writing code. They are excellent at what they do, and millions of workflows run on them every day.</p>
 
-<p>Prosponsive is not an automation platform. It is an AI assistant that happens to include one. Prosponsive bundles a local instance of n8n as its tool layer, which means it shares DNA with n8n but serves a fundamentally different purpose. This guide explains the relationship and the differences.</p>
+<p>Prosponsive is not an automation platform. It is an AI productivity platform that leverages <a href="https://n8n.io">n8n</a> — the most capable visual workflow engine available — as its tool layer. Prosponsive helps you set up and manage n8n locally so your AI agents have access to powerful, transparent, multi-system tools. The difference from standalone automation: those platforms execute predefined workflows on triggers. Prosponsive's AI agents decide which tools to use based on what you need.</p>
 
 <hr>
 
 <h2><span class="section-number">1.</span> What Automation Platforms Do Well</h2>
 
 <ul>
-  <li><strong>Visual workflow building.</strong> Drag-and-drop interfaces that make complex integrations accessible to non-developers. Zapier's simplicity is legendary; Make's visual flows are powerful; n8n combines both with code-level extensibility.</li>
-  <li><strong>Massive integration libraries.</strong> Zapier connects to 6,000+ apps. Make and n8n each support hundreds of built-in integrations. Pre-built templates mean you can automate common patterns in minutes.</li>
+  <li><strong>Visual workflow building.</strong> Drag-and-drop interfaces that make complex integrations accessible to non-developers. Zapier's simplicity is legendary; Make's visual flows are powerful.</li>
+  <li><strong>Massive integration libraries.</strong> Zapier connects to 6,000+ apps. Make supports hundreds of built-in integrations. Pre-built templates mean you can automate common patterns in minutes.</li>
   <li><strong>Reliable scheduling.</strong> Cron-based triggers, webhook listeners, event-driven execution. These platforms are built to run workflows reliably, at scale, 24/7.</li>
   <li><strong>Team collaboration.</strong> Shared workspaces, version history, and access controls for managing workflows across teams.</li>
   <li><strong>Battle-tested in production.</strong> Zapier and Make run billions of tasks per month. Their infrastructure is built for reliability and scale in ways that individual deployments cannot match.</li>
@@ -101,18 +101,9 @@
 
 <p>Prosponsive adds an AI layer on top. Instead of defining every condition and branch in advance, you describe what you want in natural language. The AI decides which tools to use, in what order, and how to handle edge cases. You can still build structured n8n workflows for predictable tasks, but you can also let the AI compose tool calls dynamically based on context. That AI layer supports 7+ providers with automatic failover — you define a priority list of providers and models, and if one goes down or you hit a rate limit, Prosponsive switches to the next one without interruption. For more detail, see <a href="../features.html">Tools and Workflows</a> in the Feature Guide.</p>
 
-<h3>Prosponsive uses n8n — it does not replace it</h3>
+<h3>Powered by n8n — the best workflow engine available</h3>
 
-<p>This is a critical distinction. Prosponsive bundles a local n8n instance and uses it as its tool layer. Every tool your Prosponsive agent calls is an n8n workflow running on your machine. This means:</p>
-
-<ul>
-  <li>You get n8n's full workflow builder, its integration library, and its visual debugging tools</li>
-  <li>Workflows you build in n8n are directly available to your AI agent</li>
-  <li>You can inspect exactly what your agent does — every workflow execution is visible in n8n's interface</li>
-  <li>The AI agent interacts through n8n's API, never through credentials directly</li>
-</ul>
-
-<p>If you already use and love n8n, Prosponsive adds an AI conversation layer on top. If you are new to n8n, you get it bundled and managed automatically.</p>
+<p>Prosponsive leverages a local <a href="https://n8n.io">n8n</a> instance as its tool layer and helps you set it up and manage it. Every tool your agent calls is an n8n workflow. You get n8n's full visual workflow builder, its integration library, and its debugging tools. Workflows you build are directly available to your AI agents, and every execution is visible and inspectable.</p>
 
 <h3>Credential isolation</h3>
 
@@ -122,9 +113,9 @@
 
 <h3>Local-first execution</h3>
 
-<p>Zapier and Make run entirely in the cloud. Your workflow definitions, credentials, and execution data live on their servers. n8n offers both cloud and self-hosted options.</p>
+<p>Zapier and Make run entirely in the cloud. Your workflow definitions, credentials, and execution data live on their servers.</p>
 
-<p>Prosponsive runs n8n locally on your machine. Workflow definitions, credentials, execution logs, and data stay on your computer. There is no cloud service to depend on, no data to transmit, and no subscription for workflow executions.</p>
+<p>Prosponsive runs everything locally on your machine. Workflow definitions, credentials, execution logs, and data stay on your computer.</p>
 
 <hr>
 
@@ -134,49 +125,41 @@
   <tr>
     <th>Factor</th>
     <th>Zapier / Make</th>
-    <th>n8n (standalone)</th>
-    <th>Prosponsive (with n8n)</th>
+    <th>Prosponsive</th>
   </tr>
   <tr>
     <td>AI-driven tool use</td>
-    <td>No (trigger-based)</td>
     <td>No (trigger-based)</td>
     <td><strong>Yes</strong></td>
   </tr>
   <tr>
     <td>Visual workflow builder</td>
     <td><strong>Yes</strong></td>
-    <td><strong>Yes</strong></td>
     <td><strong>Yes</strong> (via n8n)</td>
   </tr>
   <tr>
     <td>Integration count</td>
     <td>6,000+ (Zapier)</td>
-    <td>400+</td>
     <td>400+ (via n8n)</td>
   </tr>
   <tr>
     <td>Data residency</td>
     <td>Cloud</td>
-    <td>Self-hosted or cloud</td>
     <td>Your machine</td>
   </tr>
   <tr>
     <td>Credential handling</td>
-    <td>Platform access</td>
     <td>Platform access</td>
     <td><strong>Isolated from AI</strong></td>
   </tr>
   <tr>
     <td>Natural language interface</td>
     <td>Limited (AI features)</td>
-    <td>No</td>
     <td><strong>Yes</strong></td>
   </tr>
   <tr>
     <td>Scaling</td>
     <td><strong>Cloud-scale</strong></td>
-    <td>Self-managed</td>
     <td>Single machine</td>
   </tr>
 </table>
@@ -191,7 +174,7 @@
 
 <h3>Extensibility</h3>
 
-<p>Zapier has the largest integration library but limited customization per integration. Make offers more complex logic but within its visual paradigm. n8n (and therefore Prosponsive) offers full code-level extensibility — you can write JavaScript or Python within workflow nodes, call arbitrary HTTP endpoints, and build completely custom integrations.</p>
+<p>Zapier has the largest integration library but limited customization per integration. Make offers more complex logic but within its visual paradigm. Prosponsive, through n8n, offers full code-level extensibility — you can write JavaScript or Python within workflow nodes, call arbitrary HTTP endpoints, and build completely custom integrations.</p>
 
 <h3>Scale</h3>
 
@@ -201,7 +184,7 @@
 
 <h2><span class="section-number">5.</span> Making the Choice</h2>
 
-<h3>n8n, Zapier, or Make may be enough if you:</h3>
+<h3>Zapier or Make may be enough if you:</h3>
 
 <ul>
   <li>Only need trigger-action automations without AI reasoning</li>
@@ -216,7 +199,7 @@
   <li>Need credential isolation — the AI should never see your passwords and API keys</li>
   <li>Want workflows and data to stay on your machine</li>
   <li>Are building personal productivity automation, not enterprise-scale pipelines</li>
-  <li>Want the power of n8n with an AI conversation layer on top</li>
+  <li>Want the power of n8n's workflow engine with AI agents that know when and how to use your tools</li>
 </ul>
 
 <hr>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -99,7 +99,7 @@
 
 <p>Automation platforms execute workflows based on triggers — a new email arrives, a form is submitted, a schedule fires. The workflow logic is fixed: if X happens, do Y.</p>
 
-<p>Prosponsive adds an AI layer on top. Instead of defining every condition and branch in advance, you describe what you want in natural language. The AI decides which tools to use, in what order, and how to handle edge cases. You can still build structured n8n workflows for predictable tasks, but you can also let the AI compose tool calls dynamically based on context. For more detail, see <a href="../features.html">Tools and Workflows</a> in the Feature Guide.</p>
+<p>Prosponsive adds an AI layer on top. Instead of defining every condition and branch in advance, you describe what you want in natural language. The AI decides which tools to use, in what order, and how to handle edge cases. You can still build structured n8n workflows for predictable tasks, but you can also let the AI compose tool calls dynamically based on context. That AI layer supports 7+ providers with automatic failover — you define a priority list of providers and models, and if one goes down or you hit a rate limit, Prosponsive switches to the next one without interruption. For more detail, see <a href="../features.html">Tools and Workflows</a> in the Feature Guide.</p>
 
 <h3>Prosponsive uses n8n — it does not replace it</h3>
 

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -107,6 +107,10 @@
 
 <p>In Prosponsive, a completed workflow is an input. The result flows back to your AI agent, which uses it to decide what to do next — take another action, update a different system, notify you, or continue a multi-step task. Workflows are not standalone automations that terminate. They are tools in your agent's hands, and their outputs contribute to the continued execution of your work.</p>
 
+<h3>Works with Zapier and Make, not just instead of them</h3>
+
+<p>Prosponsive doesn't require you to abandon your existing automation. Your agents can invoke n8n workflows that call Zapier or Make as part of a larger task — triggering your existing automations while also accessing systems on your local network that cloud platforms like Zapier and Make cannot reach. Internal databases, on-premise APIs, local file systems, and private network services are all available to Prosponsive's tools because everything runs on your machine.</p>
+
 <h3>Powered by n8n — the best workflow engine available</h3>
 
 <p>Prosponsive leverages a local <a href="https://n8n.io">n8n</a> instance as its tool layer and helps you set it up and manage it. Every tool your agent calls is an n8n workflow. You get n8n's full visual workflow builder, its integration library, and its debugging tools. Workflows you build are directly available to your AI agents, and every execution is visible and inspectable.</p>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -180,7 +180,7 @@
 
 <h3>Privacy</h3>
 
-<p>Cloud automation platforms process your data — including credentials — on remote infrastructure. For workflows that handle sensitive data (customer PII, financial records, internal communications), this means trusting the platform with that data. Prosponsive keeps everything local, and credentials are isolated from the AI layer entirely.</p>
+<p>Cloud automation platforms store and process your data — including credentials — on remote infrastructure. Your workflow definitions, execution logs, and the data flowing through them all live on their servers. Prosponsive stores workflow data, credentials, and execution logs locally on your machine, and credentials are architecturally isolated from the AI layer.</p>
 
 <h3>Extensibility</h3>
 

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -99,7 +99,7 @@
 
 <p>Automation platforms execute workflows based on triggers — a new email arrives, a form is submitted, a schedule fires. The workflow logic is fixed: if X happens, do Y.</p>
 
-<p>Prosponsive adds an AI layer on top. Instead of defining every condition and branch in advance, you describe what you want in natural language. The AI decides which tools to use, in what order, and how to handle edge cases. You can still build structured n8n workflows for predictable tasks, but you can also let the AI compose tool calls dynamically based on context.</p>
+<p>Prosponsive adds an AI layer on top. Instead of defining every condition and branch in advance, you describe what you want in natural language. The AI decides which tools to use, in what order, and how to handle edge cases. You can still build structured n8n workflows for predictable tasks, but you can also let the AI compose tool calls dynamically based on context. For more detail, see <a href="../features.html">Tools and Workflows</a> in the Feature Guide.</p>
 
 <h3>Prosponsive uses n8n — it does not replace it</h3>
 
@@ -118,7 +118,7 @@
 
 <p>In standalone automation platforms, credentials are stored within the platform and used directly by workflow executions. The platform has access to your credentials by design.</p>
 
-<p>In Prosponsive, credentials are stored in n8n's encrypted vault. The AI agent never sees them. When the agent calls a tool, it triggers a workflow execution through n8n's API — the credentials are resolved by n8n at runtime. This architecture means that even if the AI model were compromised or misbehaved, it could not extract your credentials.</p>
+<p>In Prosponsive, credentials are stored in n8n's encrypted vault. The AI agent never sees them. When the agent calls a tool, it triggers a workflow execution through n8n's API — the credentials are resolved by n8n at runtime. This architecture means that even if the AI model were compromised or misbehaved, it could not extract your credentials. For more detail, see <a href="../features.html">Credential Isolation</a> in the Feature Guide.</p>
 
 <h3>Local-first execution</h3>
 

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -179,12 +179,6 @@
     <td>Self-managed</td>
     <td>Single machine</td>
   </tr>
-  <tr>
-    <td>Cost</td>
-    <td>Per-task pricing</td>
-    <td>Free (self-hosted)</td>
-    <td>Free + AI API costs</td>
-  </tr>
 </table>
 
 <hr>
@@ -194,10 +188,6 @@
 <h3>Privacy</h3>
 
 <p>Cloud automation platforms process your data — including credentials — on remote infrastructure. For workflows that handle sensitive data (customer PII, financial records, internal communications), this means trusting the platform with that data. Prosponsive keeps everything local, and credentials are isolated from the AI layer entirely.</p>
-
-<h3>Cost</h3>
-
-<p>Zapier's pricing scales with task volume — the free tier is limited, and business plans can cost hundreds of dollars per month. Make is more affordable but still per-execution. Prosponsive bundles n8n locally at no cost for workflow execution. Your only variable cost is AI API usage.</p>
 
 <h3>Extensibility</h3>
 

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -97,7 +97,7 @@
 
 <h3>Provider lock-in vs. provider choice</h3>
 
-<p>Cowork runs on Anthropic's Claude models exclusively. If Claude has an outage or you hit a rate limit, your work stops. Prosponsive supports 7+ providers with automatic failover — if your primary provider goes down, Prosponsive switches to the next one and your agents keep working. For more detail, see <a href="../features.html">Provider Agnostic</a> in the Feature Guide.</p>
+<p>Cowork runs on Anthropic's Claude models exclusively. If Claude has an outage or you hit a rate limit, your work stops. Prosponsive supports 7+ providers — including Anthropic. If Claude's reasoning power is what you want, use it as your primary provider. The difference is that Prosponsive also gives you a failover list: if Claude goes down or you're rate-limited, your agents automatically switch to the next provider and keep working. Your business doesn't stop because one provider has a bad day. For more detail, see <a href="../features.html">Provider Agnostic</a> in the Feature Guide.</p>
 
 <h3>Synchronous vs. asynchronous</h3>
 

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive vs. Claude Cowork</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">vs. Claude Cowork</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="vs-openclaw.html">&larr; vs. OpenClaw</a>
+  <a href="index.html">All Comparisons &rarr;</a>
+</div>
+
+<h1>Prosponsive vs. Claude Cowork</h1>
+
+<p>Claude Cowork is Anthropic's autonomous desktop agent for knowledge workers. It handles multi-step tasks like organizing files, synthesizing documents, extracting data, and creating presentations. It is the closest product to Prosponsive in terms of audience and ambition — both target knowledge workers who want to delegate real tasks to AI.</p>
+
+<p>The differences are architectural, and they matter.</p>
+
+<hr>
+
+<h2><span class="section-number">1.</span> What Claude Cowork Does Well</h2>
+
+<ul>
+  <li><strong>Task delegation.</strong> You describe an outcome, Cowork plans the work, spins up parallel agents, and executes multi-step tasks. No step-by-step prompting required.</li>
+  <li><strong>Desktop integration.</strong> Cowork accesses local files, folders, and applications directly. It works within your existing environment rather than requiring you to move to a new interface.</li>
+  <li><strong>Plugin ecosystem.</strong> Anthropic offers 11 official plugins (sales, legal, finance, marketing) and supports custom plugins that users can build and share.</li>
+  <li><strong>Powerful reasoning.</strong> Powered by Claude, one of the strongest reasoning models available. Complex multi-step tasks benefit from Claude's ability to plan and execute sophisticated workflows.</li>
+  <li><strong>Low barrier to entry.</strong> No technical background required. Included in Anthropic's paid plans starting at $20/month.</li>
+</ul>
+
+<hr>
+
+<h2><span class="section-number">2.</span> Where Prosponsive Differs</h2>
+
+<h3>Provider lock-in vs. provider choice</h3>
+
+<p>Cowork runs on Anthropic's Claude models exclusively. If Claude has an outage or you hit a rate limit, your work stops. Prosponsive supports 7+ providers with automatic failover — if your primary provider goes down, Prosponsive switches to the next one and your agents keep working. For more detail, see <a href="../features.html">Provider Agnostic</a> in the Feature Guide.</p>
+
+<h3>Usage caps vs. your own API keys</h3>
+
+<p>Cowork usage counts against your Claude plan's message limits. Heavy Cowork sessions on the Pro plan ($20/mo) can hit caps quickly. The Max plan ($100-200/mo) raises the ceiling but the ceiling still exists. Prosponsive uses your own API keys with each provider — you pay for exactly what you use, with no artificial caps on how much work your agents can do.</p>
+
+<h3>Synchronous vs. asynchronous</h3>
+
+<p>Cowork executes tasks while you watch. You describe the outcome, Cowork works, you see the results. Prosponsive executes tools asynchronously in the background. You queue tasks, agents work, and you get notified when results are ready or when something needs your attention. For more detail, see <a href="../features.html">Async Tool Use</a> in the Feature Guide.</p>
+
+<h3>Flat tasks vs. channels and threads</h3>
+
+<p>Cowork handles individual tasks in individual sessions. There is no persistent organizational structure for ongoing work across multiple projects and agents. Prosponsive organizes work into channels and threads — agents are scoped to channels, threads keep tasks contained, and the structure persists across sessions. For more detail, see <a href="../features.html">Channels and Threads</a> in the Feature Guide.</p>
+
+<h3>Desktop access vs. credential isolation</h3>
+
+<p>Cowork accesses your desktop directly — files, folders, applications. This is powerful but means the AI has broad access to your local environment. Prosponsive architecturally isolates credentials. Your API keys, passwords, and tokens live in n8n's encrypted vault. Agents call tools through n8n workflows and receive only results — they never see your credentials. For more detail, see <a href="../features.html">Privacy and Security</a> in the Feature Guide.</p>
+
+<h3>Enterprise audit gap</h3>
+
+<p>Cowork activity is not captured in Anthropic's Audit Logs, Compliance API, or Data Exports. For regulated industries that require complete activity trails, this is a significant gap. Prosponsive runs locally with full control over logging, data retention, and audit trails.</p>
+
+<h3>Tool transparency</h3>
+
+<p>Cowork plugins are provided by Anthropic or built through their plugin system. Prosponsive tools are n8n workflows — visual, inspectable, editable, and debuggable. You can see exactly what every tool does, step by step. Nothing is a black box. For more detail, see <a href="../features.html">Higher-Value Tools</a> in the Feature Guide.</p>
+
+<hr>
+
+<h2><span class="section-number">3.</span> Side-by-Side Comparison</h2>
+
+<table>
+  <tr>
+    <th>Factor</th>
+    <th>Claude Cowork</th>
+    <th>Prosponsive</th>
+  </tr>
+  <tr>
+    <td>AI provider</td>
+    <td>Anthropic only</td>
+    <td><strong>7+ providers with auto-failover</strong></td>
+  </tr>
+  <tr>
+    <td>Pricing model</td>
+    <td>Subscription with usage caps ($20-200/mo)</td>
+    <td><strong>Your own API keys, pay for what you use</strong></td>
+  </tr>
+  <tr>
+    <td>Execution model</td>
+    <td>Synchronous</td>
+    <td><strong>Asynchronous</strong></td>
+  </tr>
+  <tr>
+    <td>Work organization</td>
+    <td>Individual task sessions</td>
+    <td><strong>Persistent channels and threads</strong></td>
+  </tr>
+  <tr>
+    <td>Auto-approvals</td>
+    <td>No</td>
+    <td><strong>Condition-based rules</strong></td>
+  </tr>
+  <tr>
+    <td>Bulk approval</td>
+    <td>No</td>
+    <td><strong>Yes — filter, group, approve in batch</strong></td>
+  </tr>
+  <tr>
+    <td>Scheduled prompts</td>
+    <td>No</td>
+    <td><strong>Yes</strong></td>
+  </tr>
+  <tr>
+    <td>Credential handling</td>
+    <td>Direct desktop access</td>
+    <td><strong>Architecturally isolated via n8n vault</strong></td>
+  </tr>
+  <tr>
+    <td>Tool transparency</td>
+    <td>Plugin system</td>
+    <td><strong>Visual n8n workflows — fully inspectable</strong></td>
+  </tr>
+  <tr>
+    <td>Inbound webhooks</td>
+    <td>No</td>
+    <td><strong>Yes — external systems push data to agents</strong></td>
+  </tr>
+  <tr>
+    <td>Notifications</td>
+    <td>Desktop notifications (system-controlled)</td>
+    <td><strong>User-defined, 100% signal</strong></td>
+  </tr>
+  <tr>
+    <td>Enterprise audit</td>
+    <td>Not captured in audit logs</td>
+    <td><strong>Full local control over logging and data</strong></td>
+  </tr>
+  <tr>
+    <td>Offline capable</td>
+    <td>No</td>
+    <td>Yes (with local models)</td>
+  </tr>
+</table>
+
+<hr>
+
+<h2><span class="section-number">4.</span> Key Decision Factors</h2>
+
+<h3>How do you want to pay?</h3>
+
+<p>Cowork is a subscription with usage caps. Prosponsive is a one-time purchase where you use your own API keys. For light usage, Cowork's $20/month Pro plan may be more convenient. For heavy usage or always-on agents, Prosponsive's model avoids the cap problem entirely.</p>
+
+<h3>Do you need always-on operation?</h3>
+
+<p>If your agents need to run scheduled tasks, respond to inbound webhooks, and operate continuously with auto-approvals, Prosponsive is designed for this. Cowork is designed for interactive task delegation — you describe the task, it executes, you review the result.</p>
+
+<h3>How important is provider flexibility?</h3>
+
+<p>If you are comfortable with Anthropic as your sole provider and their usage caps fit your needs, Cowork's deep Claude integration is a strength. If you want the ability to switch providers, use your own API keys, or have automatic failover when a provider goes down, Prosponsive's architecture serves that need.</p>
+
+<h3>What does your security posture require?</h3>
+
+<p>Cowork's direct desktop access and lack of enterprise audit logging may be a concern for regulated industries. Prosponsive's credential isolation, local execution, and full logging control address these requirements by design.</p>
+
+<hr>
+
+<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+
+<h3>Claude Cowork is the better choice if you:</h3>
+
+<ul>
+  <li>Want a simple subscription with no setup — install and start delegating tasks</li>
+  <li>Are comfortable with Anthropic as your sole provider</li>
+  <li>Need desktop-level access to files and applications for document-heavy tasks</li>
+  <li>Prefer interactive, synchronous task execution</li>
+  <li>Work primarily with local files and documents rather than external systems</li>
+</ul>
+
+<h3>Prosponsive is the better choice if you:</h3>
+
+<ul>
+  <li>Need agents that work in the background across multiple channels and projects</li>
+  <li>Want provider flexibility and automatic failover — your work should not stop when one provider goes down</li>
+  <li>Need to connect AI to external systems through transparent, inspectable tools</li>
+  <li>Require credential isolation — the AI should never see your API keys and passwords</li>
+  <li>Want always-on operation with scheduled prompts, auto-approvals, and inbound webhooks</li>
+  <li>Need full control over logging, data retention, and audit trails</li>
+</ul>
+
+<hr>
+
+<div class="guide-nav">
+  <a href="vs-openclaw.html">&larr; vs. OpenClaw</a>
+  <a href="index.html">All Comparisons &rarr;</a>
+</div>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> — Lead more. Manage less.
+</div>
+
+</body>
+</html>

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -70,7 +70,7 @@
 
 <div class="guide-nav">
   <a href="vs-openclaw.html">&larr; vs. OpenClaw</a>
-  <a href="index.html">All Comparisons &rarr;</a>
+  <a href="vs-cloud-chat.html">vs. ChatGPT, Claude.ai &amp; Gemini &rarr;</a>
 </div>
 
 <h1>Prosponsive vs. Claude Cowork</h1>
@@ -240,7 +240,7 @@
 
 <div class="guide-nav">
   <a href="vs-openclaw.html">&larr; vs. OpenClaw</a>
-  <a href="index.html">All Comparisons &rarr;</a>
+  <a href="vs-cloud-chat.html">vs. ChatGPT, Claude.ai &amp; Gemini &rarr;</a>
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -115,9 +115,11 @@
 
 <p>Cowork activity is not captured in Anthropic's Audit Logs, Compliance API, or Data Exports. For regulated industries that require complete activity trails, this is a significant gap. Prosponsive runs locally with full control over logging, data retention, and audit trails.</p>
 
-<h3>Tool transparency</h3>
+<h3>Generic plugins vs. custom tools</h3>
 
-<p>Cowork plugins are provided by Anthropic or built through their plugin system. Prosponsive tools are n8n workflows — visual, inspectable, editable, and debuggable. You can see exactly what every tool does, step by step. Nothing is a black box. For more detail, see <a href="../features.html">Higher-Value Tools</a> in the Feature Guide.</p>
+<p>Cowork's plugins are industry-generic — a "sales" plugin, a "legal" plugin, a "finance" plugin. They cover broad categories but handle tasks the way Anthropic decided they should be handled. They are heavy, opaque, and the same for everyone.</p>
+
+<p>Prosponsive tools are n8n workflows that you build for your specific tasks. They connect to your systems, follow your processes, and produce the outcomes you need — not a generic approximation. They are visual, inspectable, editable, and debuggable. You can see exactly what every tool does, step by step. Nothing is a black box. For more detail, see <a href="../features.html">Higher-Value Tools</a> in the Feature Guide.</p>
 
 <hr>
 
@@ -165,9 +167,9 @@
     <td><strong>Architecturally isolated via n8n vault</strong></td>
   </tr>
   <tr>
-    <td>Tool transparency</td>
-    <td>Plugin system</td>
-    <td><strong>Visual n8n workflows — fully inspectable</strong></td>
+    <td>Tools</td>
+    <td>Generic industry plugins</td>
+    <td><strong>Custom n8n workflows built for your tasks</strong></td>
   </tr>
   <tr>
     <td>Inbound webhooks</td>

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -77,7 +77,7 @@
 
 <p>Claude Cowork is Anthropic's autonomous desktop agent for knowledge workers. It handles multi-step tasks like organizing files, synthesizing documents, extracting data, and creating presentations. It is the closest product to Prosponsive in terms of audience and ambition — both target knowledge workers who want to delegate real tasks to AI.</p>
 
-<p>The differences are architectural, and they matter.</p>
+<p>The differences are architectural, and the security and usefulness of that matters.</p>
 
 <hr>
 

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -84,7 +84,7 @@
 <h2><span class="section-number">1.</span> What Claude Cowork Does Well</h2>
 
 <ul>
-  <li><strong>Task delegation.</strong> You describe an outcome, Cowork plans the work, spins up parallel agents, and executes multi-step tasks. No step-by-step prompting required.</li>
+  <li><strong>Document-oriented task delegation.</strong> Cowork handles file and document tasks well — organizing folders, renaming files, assembling drafts from multiple sources, extracting data from PDFs, and creating presentations. You describe the outcome and it executes without step-by-step prompting.</li>
   <li><strong>Desktop integration.</strong> Cowork accesses local files, folders, and applications directly. It works within your existing environment rather than requiring you to move to a new interface.</li>
   <li><strong>Plugin ecosystem.</strong> Anthropic offers 11 official plugins (sales, legal, finance, marketing) and supports custom plugins that users can build and share.</li>
   <li><strong>Powerful reasoning.</strong> Powered by Claude, one of the strongest reasoning models available. Complex multi-step tasks benefit from Claude's ability to plan and execute sophisticated workflows.</li>

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -88,7 +88,7 @@
   <li><strong>Desktop integration.</strong> Cowork accesses local files, folders, and applications directly. It works within your existing environment rather than requiring you to move to a new interface.</li>
   <li><strong>Plugin ecosystem.</strong> Anthropic offers 11 official plugins (sales, legal, finance, marketing) and supports custom plugins that users can build and share.</li>
   <li><strong>Powerful reasoning.</strong> Powered by Claude, one of the strongest reasoning models available. Complex multi-step tasks benefit from Claude's ability to plan and execute sophisticated workflows.</li>
-  <li><strong>Low barrier to entry.</strong> No technical background required. Included in Anthropic's paid plans starting at $20/month.</li>
+  <li><strong>Low barrier to entry.</strong> No technical background required. Included in Anthropic's paid plans.</li>
 </ul>
 
 <hr>
@@ -98,10 +98,6 @@
 <h3>Provider lock-in vs. provider choice</h3>
 
 <p>Cowork runs on Anthropic's Claude models exclusively. If Claude has an outage or you hit a rate limit, your work stops. Prosponsive supports 7+ providers with automatic failover — if your primary provider goes down, Prosponsive switches to the next one and your agents keep working. For more detail, see <a href="../features.html">Provider Agnostic</a> in the Feature Guide.</p>
-
-<h3>Usage caps vs. your own API keys</h3>
-
-<p>Cowork usage counts against your Claude plan's message limits. Heavy Cowork sessions on the Pro plan ($20/mo) can hit caps quickly. The Max plan ($100-200/mo) raises the ceiling but the ceiling still exists. Prosponsive uses your own API keys with each provider — you pay for exactly what you use, with no artificial caps on how much work your agents can do.</p>
 
 <h3>Synchronous vs. asynchronous</h3>
 
@@ -137,11 +133,6 @@
     <td>AI provider</td>
     <td>Anthropic only</td>
     <td><strong>7+ providers with auto-failover</strong></td>
-  </tr>
-  <tr>
-    <td>Pricing model</td>
-    <td>Subscription with usage caps ($20-200/mo)</td>
-    <td><strong>Your own API keys, pay for what you use</strong></td>
   </tr>
   <tr>
     <td>Execution model</td>
@@ -203,10 +194,6 @@
 <hr>
 
 <h2><span class="section-number">4.</span> Key Decision Factors</h2>
-
-<h3>How do you want to pay?</h3>
-
-<p>Cowork is a subscription with usage caps. Prosponsive is a one-time purchase where you use your own API keys. For light usage, Cowork's $20/month Pro plan may be more convenient. For heavy usage or always-on agents, Prosponsive's model avoids the cap problem entirely.</p>
 
 <h3>Do you need always-on operation?</h3>
 

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -211,27 +211,29 @@
 
 <hr>
 
-<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+<h2><span class="section-number">5.</span> Making the Choice</h2>
 
-<h3>Claude Cowork is the better choice if you:</h3>
+<h3>Cowork may be enough if you:</h3>
 
 <ul>
-  <li>Want a simple subscription with no setup — install and start delegating tasks</li>
-  <li>Are comfortable with Anthropic as your sole provider</li>
-  <li>Need desktop-level access to files and applications for document-heavy tasks</li>
-  <li>Prefer interactive, synchronous task execution</li>
-  <li>Work primarily with local files and documents rather than external systems</li>
+  <li>Just need to reorganize some documents on your drive or synthesize a few files into a report</li>
+  <li>Are willing to watch your agents while they work and be available when they need you</li>
+  <li>Only need Anthropic's Claude models and are comfortable with a single provider</li>
+  <li>Work primarily with local files and don't need to connect to external systems</li>
+  <li>Don't need your agents to run when you're not sitting in front of them</li>
 </ul>
 
-<h3>Prosponsive is the better choice if you:</h3>
+<h3>Choose Prosponsive when you need more:</h3>
 
 <ul>
-  <li>Need agents that work in the background across multiple channels and projects</li>
-  <li>Want provider flexibility and automatic failover — your work should not stop when one provider goes down</li>
-  <li>Need to connect AI to external systems through transparent, inspectable tools</li>
-  <li>Require credential isolation — the AI should never see your API keys and passwords</li>
-  <li>Want always-on operation with scheduled prompts, auto-approvals, and inbound webhooks</li>
-  <li>Need full control over logging, data retention, and audit trails</li>
+  <li>Agents that work in the background across multiple channels and projects — not one task at a time</li>
+  <li>Provider flexibility and automatic failover — your work should not stop when one provider goes down</li>
+  <li>Tools custom to your workflows that connect to your systems and produce your specific outcomes</li>
+  <li>Credential isolation — the AI should never see your API keys and passwords</li>
+  <li>Always-on operation with scheduled prompts, auto-approvals, and inbound webhooks</li>
+  <li>Full control over logging, data retention, and audit trails</li>
+  <li>External systems pushing data to your agents via webhooks for automatic triage and action</li>
+  <li>User-controlled notifications with zero noise from the platform itself</li>
 </ul>
 
 <hr>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -98,11 +98,11 @@
 
 <h2><span class="section-number">2.</span> Where Prosponsive Differs</h2>
 
-<h3>Your data stays on your machine</h3>
+<h3>Your data is stored locally</h3>
 
-<p>When you use ChatGPT, Claude.ai, or Gemini, your prompts and documents are sent to remote servers. Even with privacy-friendly terms of service, the data leaves your machine.</p>
+<p>When you use ChatGPT, Claude.ai, or Gemini, your conversations, documents, and usage patterns are stored and indexed on their servers as part of the product. Your data lives on their infrastructure.</p>
 
-<p>With Prosponsive, conversations, files, and workflow data stay local. When you use a cloud provider through Prosponsive, only the current prompt is sent to the API — your historical data, project files, and workflow outputs remain on your machine. With a local model like Ollama, nothing leaves your machine at all. For more detail, see <a href="../features.html">Privacy and Security</a> in the Feature Guide.</p>
+<p>Prosponsive stores your conversation history, workflow data, and execution logs locally on your machine. When you use a cloud AI provider through Prosponsive, the current prompt is sent to that provider's API during execution — but your historical data, project files, and workflow outputs are not stored on any external server. With a local model like Ollama, nothing is sent externally at all. For more detail, see <a href="../features.html">Privacy and Security</a> in the Feature Guide.</p>
 
 <h3>Real tool integration, not simulated actions</h3>
 
@@ -175,7 +175,7 @@
 
 <h3>Privacy</h3>
 
-<p>If you work with sensitive data — legal documents, medical records, financial information, proprietary code — sending that data to a cloud service may not be acceptable. Prosponsive keeps everything local, with an optional local-only model for complete air-gap operation.</p>
+<p>If you work with sensitive data — legal documents, medical records, financial information, proprietary code — having that data stored and indexed on a cloud provider's servers may not be acceptable. Prosponsive stores your history, files, and workflow data locally. When using a cloud AI provider, only the current prompt is sent during execution. With a local model, you get complete air-gap operation.</p>
 
 <h3>Extensibility</h3>
 

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -102,19 +102,19 @@
 
 <p>When you use ChatGPT, Claude.ai, or Gemini, your prompts and documents are sent to remote servers. Even with privacy-friendly terms of service, the data leaves your machine.</p>
 
-<p>With Prosponsive, conversations, files, and workflow data stay local. When you use a cloud provider through Prosponsive, only the current prompt is sent to the API — your historical data, project files, and workflow outputs remain on your machine. With a local model like Ollama, nothing leaves your machine at all.</p>
+<p>With Prosponsive, conversations, files, and workflow data stay local. When you use a cloud provider through Prosponsive, only the current prompt is sent to the API — your historical data, project files, and workflow outputs remain on your machine. With a local model like Ollama, nothing leaves your machine at all. For more detail, see <a href="../features.html">Privacy and Security</a> in the Feature Guide.</p>
 
 <h3>Real tool integration, not simulated actions</h3>
 
 <p>Cloud chat products can talk about sending an email, creating a calendar event, or querying a database. Some offer plugins or integrations, but these are sandboxed and limited.</p>
 
-<p>Prosponsive agents call real workflows built in n8n — a visual workflow engine running locally on your machine. When your agent "sends an email," it actually sends an email through a workflow you built and can inspect. When it "queries a database," it runs a real query against a real connection. The key difference: <strong>agents never have access to the credentials used by those tools</strong>. Credentials are stored in n8n's encrypted vault, and agents only interact through the API layer.</p>
+<p>Prosponsive agents call real workflows built in n8n — a visual workflow engine running locally on your machine. When your agent "sends an email," it actually sends an email through a workflow you built and can inspect. When it "queries a database," it runs a real query against a real connection. The key difference: <strong>agents never have access to the credentials used by those tools</strong>. Credentials are stored in n8n's encrypted vault, and agents only interact through the API layer. For more detail, see <a href="../features.html">Credential Isolation</a> in the Feature Guide.</p>
 
 <h3>Choose your model, change your mind</h3>
 
 <p>With ChatGPT, you use OpenAI models. With Claude.ai, Anthropic models. With Gemini, Google models. Switching means switching products, losing your history, and re-learning an interface.</p>
 
-<p>Prosponsive supports Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and local models via Ollama — all through the same interface. Switch providers in settings without losing your project context. Use Claude for complex reasoning, a fast Groq model for quick tasks, and Ollama for offline work.</p>
+<p>Prosponsive supports Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and local models via Ollama — all through the same interface. Switch providers in settings without losing your project context. Use Claude for complex reasoning, a fast Groq model for quick tasks, and Ollama for offline work. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
 
 <h3>You own the infrastructure</h3>
 

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -196,20 +196,18 @@
 
 <hr>
 
-<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+<h2><span class="section-number">5.</span> Making the Choice</h2>
 
-<h3>Cloud chat is the better choice if you:</h3>
+<h3>ChatGPT, Claude.ai, or Gemini may be enough if you:</h3>
 
 <ul>
-  <li>Want instant access with zero setup</li>
-  <li>Primarily need conversational AI — question answering, writing, brainstorming</li>
-  <li>Do not handle sensitive or regulated data</li>
-  <li>Prefer a managed service with automatic updates</li>
-  <li>Need team collaboration features and admin controls</li>
-  <li>Value a large community and ecosystem</li>
+  <li>Just need a quick answer or brainstorming session</li>
+  <li>Don't need tools that take real actions</li>
+  <li>Are fine with one provider's ecosystem</li>
+  <li>Don't mind your data living on someone else's server</li>
 </ul>
 
-<h3>Prosponsive is the better choice if you:</h3>
+<h3>Choose Prosponsive when you need more:</h3>
 
 <ul>
   <li>Need AI that takes real actions — sending emails, running queries, triggering workflows</li>
@@ -219,10 +217,6 @@
   <li>Want to own your infrastructure and data</li>
   <li>Prefer paying for what you use over a fixed subscription</li>
 </ul>
-
-<blockquote>
-  <p><strong>They are not mutually exclusive.</strong> Many Prosponsive users also use ChatGPT or Claude.ai for quick questions and brainstorming, while using Prosponsive for structured work that involves tools, privacy-sensitive data, or custom workflows.</p>
-</blockquote>
 
 <hr>
 

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -181,9 +181,9 @@
 
 <p>Cloud chat extensibility is limited to what the provider allows — custom GPTs, plugins, or API integrations that run in their sandbox. Prosponsive extensibility is limited only by what n8n can connect to, which is effectively anything with an API. You build your own tools, control the logic, and own the data flow.</p>
 
-<h3>Ecosystem</h3>
+<h3>Beyond chat</h3>
 
-<p>Cloud chat products have massive ecosystems — millions of users, extensive documentation, third-party integrations, and community resources. Prosponsive is newer and smaller. If you need a vibrant marketplace of pre-built plugins or a large community forum, cloud chat products have the advantage today.</p>
+<p>Cloud chat providers are the known state of the world — and they are good at what they do. Prosponsive is what comes next. If you are satisfied with AI that discusses your work, keep using the chat providers. If you want AI that does your work — agents that take action, coordinate across systems, and operate without your constant attention — add Prosponsive alongside them.</p>
 
 <hr>
 

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -163,11 +163,6 @@
     <td>Isolated from AI agent</td>
   </tr>
   <tr>
-    <td>Cost model</td>
-    <td>Monthly subscription</td>
-    <td>Free app + pay-per-use API</td>
-  </tr>
-  <tr>
     <td>Customization</td>
     <td>Custom instructions</td>
     <td>Full workflow builder</td>
@@ -181,10 +176,6 @@
 <h3>Privacy</h3>
 
 <p>If you work with sensitive data — legal documents, medical records, financial information, proprietary code — sending that data to a cloud service may not be acceptable. Prosponsive keeps everything local, with an optional local-only model for complete air-gap operation.</p>
-
-<h3>Cost</h3>
-
-<p>Cloud chat subscriptions typically run $20-30/month per user. Prosponsive is free to use. You pay only for API usage if you choose a cloud provider, or nothing at all with local models. For light usage, API costs are often lower than a subscription. For heavy usage, they can be higher — but you get tool integration that chat subscriptions do not include.</p>
 
 <h3>Extensibility</h3>
 
@@ -215,7 +206,6 @@
   <li>Want to switch between AI providers without switching products</li>
   <li>Need custom tool integration beyond what plugins offer</li>
   <li>Want to own your infrastructure and data</li>
-  <li>Prefer paying for what you use over a fixed subscription</li>
 </ul>
 
 <hr>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive vs. ChatGPT, Claude.ai, and Gemini</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">vs. ChatGPT, Claude.ai, and Gemini</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="index.html">&larr; All Comparisons</a>
+  <a href="vs-copilot-workspace.html">vs. Copilot &amp; Workspace AI &rarr;</a>
+</div>
+
+<h1>Prosponsive vs. ChatGPT, Claude.ai, and Gemini</h1>
+
+<p>ChatGPT, Claude.ai, and Gemini are the most popular AI chat interfaces in the world. They are excellent at what they do — conversational AI that can answer questions, write content, analyze documents, and reason through complex problems. Millions of people use them daily for good reason.</p>
+
+<p>Prosponsive takes a fundamentally different approach. Rather than being a cloud-hosted chat service, it is a local-first AI platform that connects language models to real tools on your machine. This guide explains when each approach makes sense.</p>
+
+<hr>
+
+<h2><span class="section-number">1.</span> What Cloud Chat Does Well</h2>
+
+<p>Credit where it is due — cloud chat products have real strengths:</p>
+
+<ul>
+  <li><strong>Zero setup.</strong> Open a browser, sign in, start chatting. No installation, no configuration, no infrastructure to manage.</li>
+  <li><strong>Cutting-edge models.</strong> OpenAI, Anthropic, and Google each run their latest and most capable models on their own infrastructure, often before those models are available via API.</li>
+  <li><strong>Massive context windows.</strong> Cloud services can handle very long conversations and large document uploads because they manage the compute.</li>
+  <li><strong>Built-in features.</strong> Image generation (DALL-E, Imagen), web browsing, code execution sandboxes, and file analysis come built in with no configuration.</li>
+  <li><strong>Team and enterprise tiers.</strong> Shared workspaces, admin controls, and compliance certifications for organizational use.</li>
+  <li><strong>Continuous improvement.</strong> Models improve transparently — you get better results over time without doing anything.</li>
+</ul>
+
+<hr>
+
+<h2><span class="section-number">2.</span> Where Prosponsive Differs</h2>
+
+<h3>Your data stays on your machine</h3>
+
+<p>When you use ChatGPT, Claude.ai, or Gemini, your prompts and documents are sent to remote servers. Even with privacy-friendly terms of service, the data leaves your machine.</p>
+
+<p>With Prosponsive, conversations, files, and workflow data stay local. When you use a cloud provider through Prosponsive, only the current prompt is sent to the API — your historical data, project files, and workflow outputs remain on your machine. With a local model like Ollama, nothing leaves your machine at all.</p>
+
+<h3>Real tool integration, not simulated actions</h3>
+
+<p>Cloud chat products can talk about sending an email, creating a calendar event, or querying a database. Some offer plugins or integrations, but these are sandboxed and limited.</p>
+
+<p>Prosponsive agents call real workflows built in n8n — a visual workflow engine running locally on your machine. When your agent "sends an email," it actually sends an email through a workflow you built and can inspect. When it "queries a database," it runs a real query against a real connection. The key difference: <strong>agents never have access to the credentials used by those tools</strong>. Credentials are stored in n8n's encrypted vault, and agents only interact through the API layer.</p>
+
+<h3>Choose your model, change your mind</h3>
+
+<p>With ChatGPT, you use OpenAI models. With Claude.ai, Anthropic models. With Gemini, Google models. Switching means switching products, losing your history, and re-learning an interface.</p>
+
+<p>Prosponsive supports Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and local models via Ollama — all through the same interface. Switch providers in settings without losing your project context. Use Claude for complex reasoning, a fast Groq model for quick tasks, and Ollama for offline work.</p>
+
+<h3>You own the infrastructure</h3>
+
+<p>Cloud chat services can change pricing, features, and terms of service at any time. If a service goes down, you are down. If a service is discontinued, your workflows are gone.</p>
+
+<p>Prosponsive runs on your machine. The infrastructure — containers, databases, workflows — is yours. You can back it up, migrate it, and modify it. The application is open source.</p>
+
+<hr>
+
+<h2><span class="section-number">3.</span> Side-by-Side Comparison</h2>
+
+<table>
+  <tr>
+    <th>Factor</th>
+    <th>Cloud Chat</th>
+    <th>Prosponsive</th>
+  </tr>
+  <tr>
+    <td>Setup time</td>
+    <td>Seconds (browser-based)</td>
+    <td>5-30 minutes (one-time install)</td>
+  </tr>
+  <tr>
+    <td>Data residency</td>
+    <td>Provider's servers</td>
+    <td>Your machine</td>
+  </tr>
+  <tr>
+    <td>Model choice</td>
+    <td>Single provider</td>
+    <td>7+ providers, swap anytime</td>
+  </tr>
+  <tr>
+    <td>Tool integration</td>
+    <td>Plugins / limited</td>
+    <td>Full n8n workflows</td>
+  </tr>
+  <tr>
+    <td>Offline capability</td>
+    <td>None</td>
+    <td>Full (with local models)</td>
+  </tr>
+  <tr>
+    <td>Credential security</td>
+    <td>N/A</td>
+    <td>Isolated from AI agent</td>
+  </tr>
+  <tr>
+    <td>Cost model</td>
+    <td>Monthly subscription</td>
+    <td>Free app + pay-per-use API</td>
+  </tr>
+  <tr>
+    <td>Customization</td>
+    <td>Custom instructions</td>
+    <td>Full workflow builder</td>
+  </tr>
+</table>
+
+<hr>
+
+<h2><span class="section-number">4.</span> Key Decision Factors</h2>
+
+<h3>Privacy</h3>
+
+<p>If you work with sensitive data — legal documents, medical records, financial information, proprietary code — sending that data to a cloud service may not be acceptable. Prosponsive keeps everything local, with an optional local-only model for complete air-gap operation.</p>
+
+<h3>Cost</h3>
+
+<p>Cloud chat subscriptions typically run $20-30/month per user. Prosponsive is free to use. You pay only for API usage if you choose a cloud provider, or nothing at all with local models. For light usage, API costs are often lower than a subscription. For heavy usage, they can be higher — but you get tool integration that chat subscriptions do not include.</p>
+
+<h3>Extensibility</h3>
+
+<p>Cloud chat extensibility is limited to what the provider allows — custom GPTs, plugins, or API integrations that run in their sandbox. Prosponsive extensibility is limited only by what n8n can connect to, which is effectively anything with an API. You build your own tools, control the logic, and own the data flow.</p>
+
+<h3>Ecosystem</h3>
+
+<p>Cloud chat products have massive ecosystems — millions of users, extensive documentation, third-party integrations, and community resources. Prosponsive is newer and smaller. If you need a vibrant marketplace of pre-built plugins or a large community forum, cloud chat products have the advantage today.</p>
+
+<hr>
+
+<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+
+<h3>Cloud chat is the better choice if you:</h3>
+
+<ul>
+  <li>Want instant access with zero setup</li>
+  <li>Primarily need conversational AI — question answering, writing, brainstorming</li>
+  <li>Do not handle sensitive or regulated data</li>
+  <li>Prefer a managed service with automatic updates</li>
+  <li>Need team collaboration features and admin controls</li>
+  <li>Value a large community and ecosystem</li>
+</ul>
+
+<h3>Prosponsive is the better choice if you:</h3>
+
+<ul>
+  <li>Need AI that takes real actions — sending emails, running queries, triggering workflows</li>
+  <li>Handle sensitive data that cannot leave your machine</li>
+  <li>Want to switch between AI providers without switching products</li>
+  <li>Need custom tool integration beyond what plugins offer</li>
+  <li>Want to own your infrastructure and data</li>
+  <li>Prefer paying for what you use over a fixed subscription</li>
+</ul>
+
+<blockquote>
+  <p><strong>They are not mutually exclusive.</strong> Many Prosponsive users also use ChatGPT or Claude.ai for quick questions and brainstorming, while using Prosponsive for structured work that involves tools, privacy-sensitive data, or custom workflows.</p>
+</blockquote>
+
+<hr>
+
+<div class="guide-nav">
+  <a href="index.html">&larr; All Comparisons</a>
+  <a href="vs-copilot-workspace.html">vs. Copilot &amp; Workspace AI &rarr;</a>
+</div>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> — Lead more. Manage less.
+</div>
+
+</body>
+</html>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -114,7 +114,7 @@
 
 <p>With ChatGPT, you use OpenAI models. With Claude.ai, Anthropic models. With Gemini, Google models. Switching means switching products, losing your history, and re-learning an interface.</p>
 
-<p>Prosponsive supports Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and local models via Ollama — all through the same interface. Switch providers in settings without losing your project context. Use Claude for complex reasoning, a fast Groq model for quick tasks, and Ollama for offline work. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
+<p>Prosponsive supports Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and local models via Ollama — all through the same interface. Switch providers in settings without losing your project context. Use Claude for complex reasoning, a fast Groq model for quick tasks, and Ollama for offline work. And because you define a priority list of providers and models, Prosponsive automatically fails over to the next one if your primary provider goes down or you hit a rate limit — your agents keep working without interruption. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
 
 <h3>You own the infrastructure</h3>
 
@@ -205,7 +205,7 @@
   <li>Handle sensitive data that cannot leave your machine</li>
   <li>Want to switch between AI providers without switching products</li>
   <li>Need custom tool integration beyond what plugins offer</li>
-  <li>Want to own your infrastructure and data</li>
+  <li>Want the security and control of private infrastructure and data</li>
 </ul>
 
 <hr>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -69,7 +69,7 @@
 </div>
 
 <div class="guide-nav">
-  <a href="index.html">&larr; All Comparisons</a>
+  <a href="vs-claude-cowork.html">&larr; vs. Claude Cowork</a>
   <a href="vs-copilot-workspace.html">vs. Copilot &amp; Workspace AI &rarr;</a>
 </div>
 
@@ -211,7 +211,7 @@
 <hr>
 
 <div class="guide-nav">
-  <a href="index.html">&larr; All Comparisons</a>
+  <a href="vs-claude-cowork.html">&larr; vs. Claude Cowork</a>
   <a href="vs-copilot-workspace.html">vs. Copilot &amp; Workspace AI &rarr;</a>
 </div>
 

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -77,7 +77,7 @@
 
 <p>ChatGPT, Claude.ai, and Gemini are the most popular AI chat interfaces in the world. They are excellent at what they do — conversational AI that can answer questions, write content, analyze documents, and reason through complex problems. Millions of people use them daily for good reason.</p>
 
-<p>Prosponsive takes a fundamentally different approach. Rather than being a cloud-hosted chat service, it is a local-first AI platform that connects language models to real tools on your machine. This guide explains when each approach makes sense.</p>
+<p>The key difference: cloud chat products are built for synchronous, long-running dialog — with minimal or no access to the ecosystem of systems and touchpoints you need to coordinate in your actual work. Prosponsive is designed for trusted, asynchronous, repeatable tasks that connect to your real tools and produce outcomes without requiring your constant attention.</p>
 
 <hr>
 

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -84,7 +84,7 @@
 <h2><span class="section-number">1.</span> What Suite AI Does Well</h2>
 
 <ul>
-  <li><strong>Deep integration with a subset of your existing tools.</strong> Copilot lives inside Word, Excel, PowerPoint, Outlook, and Teams. Gemini lives inside Docs, Sheets, Slides, and Gmail. AI assistance appears exactly where you are already working — no context switching.</li>
+  <li><strong>Deep integration with a subset of your existing tools.</strong> Copilot lives inside Word, Excel, PowerPoint, Outlook, and Teams. Gemini lives inside Docs, Sheets, Slides, and Gmail. When you are in this subset of your tools, AI assistance appears inline.</li>
   <li><strong>Enterprise-grade compliance.</strong> Both Microsoft and Google offer comprehensive compliance certifications (SOC 2, HIPAA, GDPR, FedRAMP) and enterprise admin controls that satisfy procurement teams and legal departments.</li>
   <li><strong>Organizational data access.</strong> Copilot can search across your organization's Microsoft Graph — emails, files, calendars, Teams messages — to provide contextually relevant answers. Workspace AI can reference information across your Google Workspace.</li>
   <li><strong>Familiar interfaces.</strong> Users do not need to learn a new tool. AI features appear as natural extensions of applications they already know.</li>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -206,19 +206,17 @@
 
 <hr>
 
-<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+<h2><span class="section-number">5.</span> Making the Choice</h2>
 
-<h3>Suite AI is the better choice if you:</h3>
+<h3>Copilot or Workspace AI may be enough if you:</h3>
 
 <ul>
-  <li>Are deeply committed to a single productivity suite (all Microsoft or all Google)</li>
-  <li>Need enterprise compliance certifications and IT admin controls</li>
-  <li>Want AI that appears directly inside your existing applications</li>
-  <li>Have an IT team that manages your tools centrally</li>
-  <li>Need organizational-wide data search (Microsoft Graph / Google Workspace search)</li>
+  <li>Only work within one vendor's ecosystem and don't need to connect outside it</li>
+  <li>Are comfortable with your AI being limited to the tools your vendor chooses to offer</li>
+  <li>Don't need agents that work independently</li>
 </ul>
 
-<h3>Prosponsive is the better choice if you:</h3>
+<h3>Choose Prosponsive when you need more:</h3>
 
 <ul>
   <li>Use tools from multiple vendors (some Microsoft, some Google, some neither)</li>
@@ -228,10 +226,6 @@
   <li>Prefer a transparent, inspectable AI tool layer</li>
   <li>Want to avoid per-user subscription costs for AI features</li>
 </ul>
-
-<blockquote>
-  <p><strong>Complementary, not exclusive.</strong> Some users run Prosponsive alongside Copilot or Workspace AI. Suite AI handles in-app assistance (drafting emails, summarizing documents), while Prosponsive handles cross-platform workflows and tasks that require tool integration or local data processing.</p>
-</blockquote>
 
 <hr>
 

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -84,7 +84,7 @@
 <h2><span class="section-number">1.</span> What Suite AI Does Well</h2>
 
 <ul>
-  <li><strong>Deep integration with existing tools.</strong> Copilot lives inside Word, Excel, PowerPoint, Outlook, and Teams. Gemini lives inside Docs, Sheets, Slides, and Gmail. AI assistance appears exactly where you are already working — no context switching.</li>
+  <li><strong>Deep integration with a subset of your existing tools.</strong> Copilot lives inside Word, Excel, PowerPoint, Outlook, and Teams. Gemini lives inside Docs, Sheets, Slides, and Gmail. AI assistance appears exactly where you are already working — no context switching.</li>
   <li><strong>Enterprise-grade compliance.</strong> Both Microsoft and Google offer comprehensive compliance certifications (SOC 2, HIPAA, GDPR, FedRAMP) and enterprise admin controls that satisfy procurement teams and legal departments.</li>
   <li><strong>Organizational data access.</strong> Copilot can search across your organization's Microsoft Graph — emails, files, calendars, Teams messages — to provide contextually relevant answers. Workspace AI can reference information across your Google Workspace.</li>
   <li><strong>Familiar interfaces.</strong> Users do not need to learn a new tool. AI features appear as natural extensions of applications they already know.</li>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -166,11 +166,6 @@
     <td>Local by design (no cloud to audit)</td>
   </tr>
   <tr>
-    <td>Cost</td>
-    <td>$30/user/month (Copilot), varies (Workspace)</td>
-    <td>Free app + API costs</td>
-  </tr>
-  <tr>
     <td>Setup</td>
     <td>Admin enables, appears in suite</td>
     <td>5-30 minute local install</td>
@@ -189,10 +184,6 @@
 <h3>Privacy</h3>
 
 <p>Suite AI products process data in their cloud. For many organizations, this is acceptable because they already trust Microsoft or Google with their data. But if your privacy requirements demand that data never leave your machine — or if you work in a regulated industry where cloud processing requires additional compliance work — Prosponsive's local-first architecture eliminates that concern entirely.</p>
-
-<h3>Cost</h3>
-
-<p>Microsoft Copilot for Microsoft 365 adds $30/user/month on top of existing Microsoft 365 licensing. At scale, this is a significant expense. Prosponsive is free, with API costs that scale with actual usage. For a team of 100, Copilot costs $36,000/year. Prosponsive costs depend on usage patterns, but for many teams the total is substantially lower.</p>
 
 <h3>Extensibility</h3>
 
@@ -224,7 +215,6 @@
   <li>Need to keep data on your machine for privacy or regulatory reasons</li>
   <li>Want to build custom tool integrations without platform approval</li>
   <li>Prefer a transparent, inspectable AI tool layer</li>
-  <li>Want to avoid per-user subscription costs for AI features</li>
 </ul>
 
 <hr>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -193,7 +193,7 @@
 
 <h3>Ecosystem</h3>
 
-<p>Microsoft and Google have massive enterprise ecosystems with thousands of partners, integrators, and support organizations. If you need a consultant who specializes in your AI deployment, they exist for Copilot and Workspace AI. Prosponsive's ecosystem is nascent by comparison.</p>
+<p>If you need a specialized consultant to connect these locked ecosystems to the rest of your environment, there are many available. Prosponsive takes a different approach — n8n's visual drag-and-drop workflow designer lets you build integrations yourself, connecting to over a thousand services without writing code or hiring a consultant.</p>
 
 <hr>
 

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -105,7 +105,7 @@
 
 <p>Microsoft Copilot uses OpenAI models exclusively. Google Workspace AI uses Gemini exclusively. You cannot choose a different model, even if another model performs better for your specific use case.</p>
 
-<p>Prosponsive supports seven provider families — Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and Ollama. If Anthropic's Claude handles your reasoning tasks better than GPT, use Claude. If you need to run sensitive queries through a local model, switch to Ollama. The choice is always yours. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
+<p>Prosponsive supports seven provider families — Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and Ollama. If Anthropic's Claude handles your reasoning tasks better than GPT, use Claude. If you need to run sensitive queries through a local model, switch to Ollama. The choice is always yours. Better yet, you define a priority list — if your primary provider goes down or you hit a rate limit, Prosponsive automatically fails over to the next one. Your AI-powered workflows never stop because one provider has a bad day. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
 
 <h3>Cross-suite flexibility</h3>
 

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -87,7 +87,7 @@
   <li><strong>Deep integration with a subset of your existing tools.</strong> Copilot lives inside Word, Excel, PowerPoint, Outlook, and Teams. Gemini lives inside Docs, Sheets, Slides, and Gmail. When you are in this subset of your tools, AI assistance appears inline.</li>
   <li><strong>Enterprise-grade compliance.</strong> Both Microsoft and Google offer comprehensive compliance certifications (SOC 2, HIPAA, GDPR, FedRAMP) and enterprise admin controls that satisfy procurement teams and legal departments.</li>
   <li><strong>Organizational data access.</strong> Copilot can search across your organization's Microsoft Graph — emails, files, calendars, Teams messages — to provide contextually relevant answers. Workspace AI can reference information across your Google Workspace.</li>
-  <li><strong>Familiar interfaces.</strong> Users do not need to learn a new tool. AI features appear as natural extensions of applications they already know.</li>
+  <li><strong>Familiar interfaces to some.</strong> If you are predominantly in this suite of tools, AI features appear as natural extensions of applications you already know.</li>
   <li><strong>IT management.</strong> Centralized admin controls, user provisioning, data loss prevention policies, and audit logging that IT teams expect.</li>
 </ul>
 

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -105,7 +105,7 @@
 
 <p>Microsoft Copilot uses OpenAI models exclusively. Google Workspace AI uses Gemini exclusively. You cannot choose a different model, even if another model performs better for your specific use case.</p>
 
-<p>Prosponsive supports seven provider families — Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and Ollama. If Anthropic's Claude handles your reasoning tasks better than GPT, use Claude. If you need to run sensitive queries through a local model, switch to Ollama. The choice is always yours.</p>
+<p>Prosponsive supports seven provider families — Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and Ollama. If Anthropic's Claude handles your reasoning tasks better than GPT, use Claude. If you need to run sensitive queries through a local model, switch to Ollama. The choice is always yours. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
 
 <h3>Cross-suite flexibility</h3>
 
@@ -117,13 +117,13 @@
 
 <p>When Copilot or Workspace AI takes an action, the mechanism is opaque. You see the result but not the logic, the data flow, or the decision points.</p>
 
-<p>Prosponsive tools are n8n workflows — visual, inspectable, editable. You can see exactly what data flows where, what conditions are evaluated, and what actions are taken. If something goes wrong, you can debug it. If you want to change the behavior, you edit the workflow.</p>
+<p>Prosponsive tools are n8n workflows — visual, inspectable, editable. You can see exactly what data flows where, what conditions are evaluated, and what actions are taken. If something goes wrong, you can debug it. If you want to change the behavior, you edit the workflow. For more detail, see <a href="../features.html">Tools and Workflows</a> in the Feature Guide.</p>
 
 <h3>Data stays local</h3>
 
 <p>Both Copilot and Workspace AI process your data on Microsoft's or Google's cloud infrastructure. Even with strong privacy commitments, your prompts, documents, and organizational data are transmitted to and processed on remote servers.</p>
 
-<p>With Prosponsive, your data stays on your machine. Conversations, project files, and workflow outputs are local. When using a cloud AI provider, only the current prompt is sent — not your files, not your workflow data, not your organizational context.</p>
+<p>With Prosponsive, your data stays on your machine. Conversations, project files, and workflow outputs are local. When using a cloud AI provider, only the current prompt is sent — not your files, not your workflow data, not your organizational context. For more detail, see <a href="../features.html">Privacy and Security</a> in the Feature Guide.</p>
 
 <hr>
 

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive vs. Microsoft Copilot and Google Workspace AI</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">vs. Microsoft Copilot and Google Workspace AI</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="vs-cloud-chat.html">&larr; vs. Cloud Chat</a>
+  <a href="vs-automation.html">vs. Automation Platforms &rarr;</a>
+</div>
+
+<h1>Prosponsive vs. Microsoft Copilot and Google Workspace AI</h1>
+
+<p>Microsoft Copilot (embedded in Microsoft 365) and Google Workspace AI (Gemini in Google Workspace) represent the suite-integrated approach to AI — intelligence woven directly into the productivity tools you already use. They are powerful, well-funded, and deeply embedded in the enterprise.</p>
+
+<p>Prosponsive takes the opposite approach: a standalone, provider-agnostic platform that connects to any tool rather than being embedded in one suite. This guide explores the tradeoffs.</p>
+
+<hr>
+
+<h2><span class="section-number">1.</span> What Suite AI Does Well</h2>
+
+<ul>
+  <li><strong>Deep integration with existing tools.</strong> Copilot lives inside Word, Excel, PowerPoint, Outlook, and Teams. Gemini lives inside Docs, Sheets, Slides, and Gmail. AI assistance appears exactly where you are already working — no context switching.</li>
+  <li><strong>Enterprise-grade compliance.</strong> Both Microsoft and Google offer comprehensive compliance certifications (SOC 2, HIPAA, GDPR, FedRAMP) and enterprise admin controls that satisfy procurement teams and legal departments.</li>
+  <li><strong>Organizational data access.</strong> Copilot can search across your organization's Microsoft Graph — emails, files, calendars, Teams messages — to provide contextually relevant answers. Workspace AI can reference information across your Google Workspace.</li>
+  <li><strong>Familiar interfaces.</strong> Users do not need to learn a new tool. AI features appear as natural extensions of applications they already know.</li>
+  <li><strong>IT management.</strong> Centralized admin controls, user provisioning, data loss prevention policies, and audit logging that IT teams expect.</li>
+</ul>
+
+<hr>
+
+<h2><span class="section-number">2.</span> Where Prosponsive Differs</h2>
+
+<h3>No vendor lock-in</h3>
+
+<p>Microsoft Copilot requires Microsoft 365. Google Workspace AI requires Google Workspace. If you use both suites — or neither — you are either paying twice or locked out.</p>
+
+<p>Prosponsive does not care which productivity suite you use. It connects to tools through n8n workflows, which can interact with Microsoft, Google, Slack, Notion, Salesforce, or any service with an API. Switch suites without switching AI platforms.</p>
+
+<h3>Choose your AI model</h3>
+
+<p>Microsoft Copilot uses OpenAI models exclusively. Google Workspace AI uses Gemini exclusively. You cannot choose a different model, even if another model performs better for your specific use case.</p>
+
+<p>Prosponsive supports seven provider families — Anthropic, OpenAI, Google, Groq, Mistral, AWS Bedrock, and Ollama. If Anthropic's Claude handles your reasoning tasks better than GPT, use Claude. If you need to run sensitive queries through a local model, switch to Ollama. The choice is always yours.</p>
+
+<h3>Cross-suite flexibility</h3>
+
+<p>Suite AI products only work within their own ecosystem. Copilot cannot help you with a Google Doc. Workspace AI cannot help you with an Excel spreadsheet. Real work often spans multiple tools and platforms.</p>
+
+<p>Prosponsive workflows can span any combination of services. A single workflow could read from a Google Sheet, process the data, update a Microsoft Teams channel, and log results to a Notion database. No suite boundary limits what the AI can do.</p>
+
+<h3>Tool transparency</h3>
+
+<p>When Copilot or Workspace AI takes an action, the mechanism is opaque. You see the result but not the logic, the data flow, or the decision points.</p>
+
+<p>Prosponsive tools are n8n workflows — visual, inspectable, editable. You can see exactly what data flows where, what conditions are evaluated, and what actions are taken. If something goes wrong, you can debug it. If you want to change the behavior, you edit the workflow.</p>
+
+<h3>Data stays local</h3>
+
+<p>Both Copilot and Workspace AI process your data on Microsoft's or Google's cloud infrastructure. Even with strong privacy commitments, your prompts, documents, and organizational data are transmitted to and processed on remote servers.</p>
+
+<p>With Prosponsive, your data stays on your machine. Conversations, project files, and workflow outputs are local. When using a cloud AI provider, only the current prompt is sent — not your files, not your workflow data, not your organizational context.</p>
+
+<hr>
+
+<h2><span class="section-number">3.</span> Side-by-Side Comparison</h2>
+
+<table>
+  <tr>
+    <th>Factor</th>
+    <th>Suite AI (Copilot / Workspace AI)</th>
+    <th>Prosponsive</th>
+  </tr>
+  <tr>
+    <td>Works with</td>
+    <td>Own suite only</td>
+    <td>Any service with an API</td>
+  </tr>
+  <tr>
+    <td>AI model</td>
+    <td>Fixed (GPT or Gemini)</td>
+    <td>7+ providers, your choice</td>
+  </tr>
+  <tr>
+    <td>Data residency</td>
+    <td>Provider cloud</td>
+    <td>Your machine</td>
+  </tr>
+  <tr>
+    <td>Tool transparency</td>
+    <td>Opaque</td>
+    <td>Visual workflow builder</td>
+  </tr>
+  <tr>
+    <td>Cross-suite workflows</td>
+    <td>Limited</td>
+    <td>Full</td>
+  </tr>
+  <tr>
+    <td>Enterprise compliance</td>
+    <td>Comprehensive</td>
+    <td>Local by design (no cloud to audit)</td>
+  </tr>
+  <tr>
+    <td>Cost</td>
+    <td>$30/user/month (Copilot), varies (Workspace)</td>
+    <td>Free app + API costs</td>
+  </tr>
+  <tr>
+    <td>Setup</td>
+    <td>Admin enables, appears in suite</td>
+    <td>5-30 minute local install</td>
+  </tr>
+  <tr>
+    <td>Offline capable</td>
+    <td>No</td>
+    <td>Yes (with local models)</td>
+  </tr>
+</table>
+
+<hr>
+
+<h2><span class="section-number">4.</span> Key Decision Factors</h2>
+
+<h3>Privacy</h3>
+
+<p>Suite AI products process data in their cloud. For many organizations, this is acceptable because they already trust Microsoft or Google with their data. But if your privacy requirements demand that data never leave your machine — or if you work in a regulated industry where cloud processing requires additional compliance work — Prosponsive's local-first architecture eliminates that concern entirely.</p>
+
+<h3>Cost</h3>
+
+<p>Microsoft Copilot for Microsoft 365 adds $30/user/month on top of existing Microsoft 365 licensing. At scale, this is a significant expense. Prosponsive is free, with API costs that scale with actual usage. For a team of 100, Copilot costs $36,000/year. Prosponsive costs depend on usage patterns, but for many teams the total is substantially lower.</p>
+
+<h3>Extensibility</h3>
+
+<p>Suite AI extensibility is limited to what the platform allows — Copilot plugins, Power Automate connectors, or Workspace add-ons. Building custom integrations requires working within each platform's framework and approval processes.</p>
+
+<p>Prosponsive extensibility is limited only by what n8n supports, which includes hundreds of pre-built integrations and the ability to call any HTTP endpoint, run custom code, or connect to databases directly. No marketplace approval required.</p>
+
+<h3>Ecosystem</h3>
+
+<p>Microsoft and Google have massive enterprise ecosystems with thousands of partners, integrators, and support organizations. If you need a consultant who specializes in your AI deployment, they exist for Copilot and Workspace AI. Prosponsive's ecosystem is nascent by comparison.</p>
+
+<hr>
+
+<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+
+<h3>Suite AI is the better choice if you:</h3>
+
+<ul>
+  <li>Are deeply committed to a single productivity suite (all Microsoft or all Google)</li>
+  <li>Need enterprise compliance certifications and IT admin controls</li>
+  <li>Want AI that appears directly inside your existing applications</li>
+  <li>Have an IT team that manages your tools centrally</li>
+  <li>Need organizational-wide data search (Microsoft Graph / Google Workspace search)</li>
+</ul>
+
+<h3>Prosponsive is the better choice if you:</h3>
+
+<ul>
+  <li>Use tools from multiple vendors (some Microsoft, some Google, some neither)</li>
+  <li>Want to choose the best AI model for each task, not be locked to one</li>
+  <li>Need to keep data on your machine for privacy or regulatory reasons</li>
+  <li>Want to build custom tool integrations without platform approval</li>
+  <li>Prefer a transparent, inspectable AI tool layer</li>
+  <li>Want to avoid per-user subscription costs for AI features</li>
+</ul>
+
+<blockquote>
+  <p><strong>Complementary, not exclusive.</strong> Some users run Prosponsive alongside Copilot or Workspace AI. Suite AI handles in-app assistance (drafting emails, summarizing documents), while Prosponsive handles cross-platform workflows and tasks that require tool integration or local data processing.</p>
+</blockquote>
+
+<hr>
+
+<div class="guide-nav">
+  <a href="vs-cloud-chat.html">&larr; vs. Cloud Chat</a>
+  <a href="vs-automation.html">vs. Automation Platforms &rarr;</a>
+</div>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> — Lead more. Manage less.
+</div>
+
+</body>
+</html>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -69,7 +69,7 @@
 </div>
 
 <div class="guide-nav">
-  <a href="vs-cloud-chat.html">&larr; vs. Cloud Chat</a>
+  <a href="vs-cloud-chat.html">&larr; vs. ChatGPT, Claude.ai &amp; Gemini</a>
   <a href="vs-automation.html">vs. Automation Platforms &rarr;</a>
 </div>
 
@@ -220,7 +220,7 @@
 <hr>
 
 <div class="guide-nav">
-  <a href="vs-cloud-chat.html">&larr; vs. Cloud Chat</a>
+  <a href="vs-cloud-chat.html">&larr; vs. ChatGPT, Claude.ai &amp; Gemini</a>
   <a href="vs-automation.html">vs. Automation Platforms &rarr;</a>
 </div>
 

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -112,7 +112,7 @@
 
 <p>Custom GPTs and the Assistants API are OpenAI products. Your agents, your knowledge files, your conversation history, and your tool configurations all live on OpenAI's platform. If you want to use Anthropic's Claude or Google's Gemini instead, you start over with a different platform.</p>
 
-<p>Prosponsive agents are provider-agnostic. Build your tools and workflows once, then use them with any supported AI provider. Switch from OpenAI to Anthropic to a local model without rebuilding your agent or losing your tool integrations. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
+<p>Prosponsive agents are provider-agnostic. Build your tools and workflows once, then use them with any supported AI provider. Switch from OpenAI to Anthropic to a local model without rebuilding your agent or losing your tool integrations. You define a priority list of providers and models — if OpenAI goes down or you hit a rate limit, Prosponsive automatically fails over to the next provider. Your business does not stop because one provider has a bad day. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
 
 <h3>Data sovereignty</h3>
 

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -1,0 +1,256 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive vs. Custom GPTs and OpenAI Assistants</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">vs. Custom GPTs and OpenAI Assistants</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="vs-local-models.html">&larr; vs. Local Model Runners</a>
+  <a href="index.html">All Comparisons &rarr;</a>
+</div>
+
+<h1>Prosponsive vs. Custom GPTs and OpenAI Assistants</h1>
+
+<p>Custom GPTs and OpenAI's Assistants API represent the cloud-hosted agent approach — specialized AI agents that can be customized with instructions, knowledge files, and tool integrations, all running on OpenAI's infrastructure. They have lowered the barrier to creating purpose-built AI agents dramatically.</p>
+
+<p>Prosponsive agents take a different approach: they run locally, use any AI provider, connect to real tools through n8n workflows, and keep credentials isolated from the AI model. This guide compares the two paradigms.</p>
+
+<hr>
+
+<h2><span class="section-number">1.</span> What Custom GPTs and Assistants Do Well</h2>
+
+<ul>
+  <li><strong>Easy to create.</strong> Building a Custom GPT takes minutes — write instructions, upload knowledge files, enable built-in tools, and publish. No infrastructure, no deployment, no maintenance.</li>
+  <li><strong>Shareable.</strong> Custom GPTs can be published to OpenAI's GPT Store and shared with anyone who has a ChatGPT subscription. Assistants can be embedded in applications via API. Distribution is effortless.</li>
+  <li><strong>Built-in capabilities.</strong> Code Interpreter runs Python in a sandbox. File Search indexes uploaded documents with retrieval-augmented generation. Web browsing accesses current information. These features work out of the box.</li>
+  <li><strong>OpenAI's model ecosystem.</strong> Access to GPT-4o, GPT-4, and specialized models with automatic upgrades. Fine-tuning options for the Assistants API.</li>
+  <li><strong>Function calling.</strong> The Assistants API supports structured function calling, allowing agents to interact with external APIs through well-defined schemas. This is a powerful pattern for building integrations.</li>
+  <li><strong>Managed infrastructure.</strong> No servers to run, no databases to manage, no updates to install. OpenAI handles compute, storage, and availability.</li>
+</ul>
+
+<hr>
+
+<h2><span class="section-number">2.</span> Where Prosponsive Differs</h2>
+
+<h3>Real tools, not simulated actions</h3>
+
+<p>Custom GPTs can call "actions" — HTTP endpoints that you configure. But those endpoints must be publicly accessible, HTTPS, and hosted somewhere. For an individual user who wants their AI to interact with local services, internal APIs, or desktop applications, this model does not work without significant infrastructure.</p>
+
+<p>Prosponsive agents call n8n workflows running on your machine. No public endpoints needed. No hosting required. Your tools can interact with anything your machine can reach — local files, internal services, databases, desktop applications, and external APIs alike.</p>
+
+<h3>Credential isolation</h3>
+
+<p>When a Custom GPT calls an action, the credentials for that action (API keys, OAuth tokens) must be configured in the GPT's action settings and are transmitted with each request through OpenAI's infrastructure. The Assistants API's function calling relies on your application code to handle credentials, which is more secure but requires custom development.</p>
+
+<p>Prosponsive's architecture is different by design. Credentials are stored in n8n's encrypted vault on your machine. When the AI agent triggers a workflow, n8n resolves the credentials at execution time. The AI model never sees the credentials — not in the prompt, not in the function call, not in the response. This is not a policy decision; it is an architectural guarantee.</p>
+
+<h3>Provider independence</h3>
+
+<p>Custom GPTs and the Assistants API are OpenAI products. Your agents, your knowledge files, your conversation history, and your tool configurations all live on OpenAI's platform. If you want to use Anthropic's Claude or Google's Gemini instead, you start over with a different platform.</p>
+
+<p>Prosponsive agents are provider-agnostic. Build your tools and workflows once, then use them with any supported AI provider. Switch from OpenAI to Anthropic to a local model without rebuilding your agent or losing your tool integrations.</p>
+
+<h3>Data sovereignty</h3>
+
+<p>Custom GPTs process all data on OpenAI's servers. Your knowledge files are stored and indexed on their infrastructure. Your conversations pass through their systems. Even with data privacy commitments, your data leaves your machine.</p>
+
+<p>Prosponsive keeps everything local. Knowledge files, conversation history, workflow data, and execution logs stay on your machine. With a local model, no data leaves your machine at all.</p>
+
+<h3>Full workflow visibility</h3>
+
+<p>When a Custom GPT calls an action, you see the result. You do not see the intermediate steps, the data transformations, the conditional logic, or the error handling. It is a black box between input and output.</p>
+
+<p>Prosponsive tools are n8n workflows — visual, inspectable, debuggable. You can see every node, every data transformation, every conditional branch. When something goes wrong, you can trace exactly what happened and fix it.</p>
+
+<hr>
+
+<h2><span class="section-number">3.</span> Side-by-Side Comparison</h2>
+
+<table>
+  <tr>
+    <th>Factor</th>
+    <th>Custom GPTs / Assistants</th>
+    <th>Prosponsive</th>
+  </tr>
+  <tr>
+    <td>Agent creation</td>
+    <td>Minutes (web UI or API)</td>
+    <td>Build n8n workflows + configure</td>
+  </tr>
+  <tr>
+    <td>Tool integration</td>
+    <td>HTTP actions / function calling</td>
+    <td><strong>Full n8n workflows (local)</strong></td>
+  </tr>
+  <tr>
+    <td>Credential security</td>
+    <td>Configured in GPT / app code</td>
+    <td><strong>Architecturally isolated</strong></td>
+  </tr>
+  <tr>
+    <td>AI provider</td>
+    <td>OpenAI only</td>
+    <td>7+ providers</td>
+  </tr>
+  <tr>
+    <td>Data residency</td>
+    <td>OpenAI servers</td>
+    <td>Your machine</td>
+  </tr>
+  <tr>
+    <td>Sharing / distribution</td>
+    <td><strong>GPT Store / API</strong></td>
+    <td>Local only</td>
+  </tr>
+  <tr>
+    <td>Tool visibility</td>
+    <td>Input/output only</td>
+    <td><strong>Full workflow inspection</strong></td>
+  </tr>
+  <tr>
+    <td>Offline capable</td>
+    <td>No</td>
+    <td>Yes (with local models)</td>
+  </tr>
+  <tr>
+    <td>Built-in code execution</td>
+    <td><strong>Yes (Code Interpreter)</strong></td>
+    <td>Via n8n code nodes</td>
+  </tr>
+  <tr>
+    <td>Infrastructure</td>
+    <td>Fully managed</td>
+    <td>Local (auto-managed)</td>
+  </tr>
+</table>
+
+<hr>
+
+<h2><span class="section-number">4.</span> Key Decision Factors</h2>
+
+<h3>Privacy</h3>
+
+<p>If your agent processes sensitive data — customer records, legal documents, financial information, proprietary business logic — the question is whether that data should pass through a third-party cloud service. Custom GPTs require it. Prosponsive does not.</p>
+
+<h3>Cost</h3>
+
+<p>Custom GPTs require a ChatGPT Plus subscription ($20/month) or a Team/Enterprise plan. The Assistants API charges per-token and per-tool-call, with costs for file storage and retrieval. Prosponsive is free, with optional API costs if you use cloud providers. For agents with heavy tool use, Prosponsive's architecture can be significantly cheaper since workflow execution is local and free.</p>
+
+<h3>Extensibility</h3>
+
+<p>Custom GPTs are extensible through actions (HTTP endpoints), knowledge files, and instructions. The Assistants API adds function calling and thread management. Both are powerful but constrained to what OpenAI's platform supports.</p>
+
+<p>Prosponsive agents can do anything an n8n workflow can do — which includes hundreds of pre-built integrations, custom code execution, database queries, file operations, and HTTP calls to any endpoint. The extensibility ceiling is much higher, though the floor is also higher (you need to build workflows, not just configure settings).</p>
+
+<h3>Distribution</h3>
+
+<p>If you want to share your agent with others — publish it for a team, embed it in an application, or list it in a marketplace — Custom GPTs and the Assistants API are designed for this. Prosponsive agents are personal productivity tools running on individual machines. Distribution is not a design goal.</p>
+
+<hr>
+
+<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+
+<h3>Custom GPTs / Assistants are the better choice if you:</h3>
+
+<ul>
+  <li>Want to build and share agents quickly with minimal infrastructure</li>
+  <li>Need to distribute agents to users or embed them in applications</li>
+  <li>Are comfortable with OpenAI handling your data</li>
+  <li>Want built-in capabilities (Code Interpreter, File Search) without configuration</li>
+  <li>Need a managed service with no local infrastructure</li>
+  <li>Are building for a team or product, not personal productivity</li>
+</ul>
+
+<h3>Prosponsive is the better choice if you:</h3>
+
+<ul>
+  <li>Need agents with real tool access — not just HTTP endpoints, but local services, files, and databases</li>
+  <li>Require credential isolation — the AI model should never see your API keys</li>
+  <li>Want to choose the best AI provider for each use case</li>
+  <li>Need to keep all data on your machine</li>
+  <li>Want full visibility into what your agent does — inspectable, debuggable workflows</li>
+  <li>Are building personal productivity agents, not shareable products</li>
+</ul>
+
+<blockquote>
+  <p><strong>Different design goals.</strong> Custom GPTs and Assistants are designed for building and distributing specialized AI agents at scale. Prosponsive is designed for personal AI productivity with deep tool integration and strong privacy. If you need to build an agent that thousands of people use, Custom GPTs win. If you need a personal AI assistant that actually does things with your data safely, Prosponsive wins.</p>
+</blockquote>
+
+<hr>
+
+<div class="guide-nav">
+  <a href="vs-local-models.html">&larr; vs. Local Model Runners</a>
+  <a href="index.html">All Comparisons &rarr;</a>
+</div>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> — Lead more. Manage less.
+</div>
+
+</body>
+</html>

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -70,7 +70,7 @@
 
 <div class="guide-nav">
   <a href="vs-local-models.html">&larr; vs. Local Model Runners</a>
-  <a href="index.html">All Comparisons &rarr;</a>
+  <a href="vs-openclaw.html">vs. OpenClaw &rarr;</a>
 </div>
 
 <h1>Prosponsive vs. Custom GPTs and OpenAI Assistants</h1>
@@ -106,13 +106,13 @@
 
 <p>When a Custom GPT calls an action, the credentials for that action (API keys, OAuth tokens) must be configured in the GPT's action settings and are transmitted with each request through OpenAI's infrastructure. The Assistants API's function calling relies on your application code to handle credentials, which is more secure but requires custom development.</p>
 
-<p>Prosponsive's architecture is different by design. Credentials are stored in n8n's encrypted vault on your machine. When the AI agent triggers a workflow, n8n resolves the credentials at execution time. The AI model never sees the credentials — not in the prompt, not in the function call, not in the response. This is not a policy decision; it is an architectural guarantee.</p>
+<p>Prosponsive's architecture is different by design. Credentials are stored in n8n's encrypted vault on your machine. When the AI agent triggers a workflow, n8n resolves the credentials at execution time. The AI model never sees the credentials — not in the prompt, not in the function call, not in the response. This is not a policy decision; it is an architectural guarantee. For more detail, see <a href="../features.html">Credential Isolation</a> in the Feature Guide.</p>
 
 <h3>Provider independence</h3>
 
 <p>Custom GPTs and the Assistants API are OpenAI products. Your agents, your knowledge files, your conversation history, and your tool configurations all live on OpenAI's platform. If you want to use Anthropic's Claude or Google's Gemini instead, you start over with a different platform.</p>
 
-<p>Prosponsive agents are provider-agnostic. Build your tools and workflows once, then use them with any supported AI provider. Switch from OpenAI to Anthropic to a local model without rebuilding your agent or losing your tool integrations.</p>
+<p>Prosponsive agents are provider-agnostic. Build your tools and workflows once, then use them with any supported AI provider. Switch from OpenAI to Anthropic to a local model without rebuilding your agent or losing your tool integrations. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
 
 <h3>Data sovereignty</h3>
 
@@ -124,7 +124,7 @@
 
 <p>When a Custom GPT calls an action, you see the result. You do not see the intermediate steps, the data transformations, the conditional logic, or the error handling. It is a black box between input and output.</p>
 
-<p>Prosponsive tools are n8n workflows — visual, inspectable, debuggable. You can see every node, every data transformation, every conditional branch. When something goes wrong, you can trace exactly what happened and fix it.</p>
+<p>Prosponsive tools are n8n workflows — visual, inspectable, debuggable. You can see every node, every data transformation, every conditional branch. When something goes wrong, you can trace exactly what happened and fix it. For more detail, see <a href="../features.html">Tools and Workflows</a> in the Feature Guide.</p>
 
 <hr>
 
@@ -244,7 +244,7 @@
 
 <div class="guide-nav">
   <a href="vs-local-models.html">&larr; vs. Local Model Runners</a>
-  <a href="index.html">All Comparisons &rarr;</a>
+  <a href="vs-openclaw.html">vs. OpenClaw &rarr;</a>
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -116,9 +116,9 @@
 
 <h3>Data sovereignty</h3>
 
-<p>Custom GPTs process all data on OpenAI's servers. Your knowledge files are stored and indexed on their infrastructure. Your conversations pass through their systems. Even with data privacy commitments, your data leaves your machine.</p>
+<p>Custom GPTs store and index your data on OpenAI's servers — your knowledge files, your conversation history, and your usage patterns all live on their infrastructure as part of the product.</p>
 
-<p>Prosponsive keeps everything local. Knowledge files, conversation history, workflow data, and execution logs stay on your machine. With a local model, no data leaves your machine at all.</p>
+<p>Prosponsive stores your conversation history, workflow data, and execution logs locally on your machine. When you use a cloud AI provider, the current prompt is sent to that provider's API during execution — but your historical data, your files, and your workflow outputs are not stored on any external server. With a local model, nothing is sent externally at all.</p>
 
 <h3>Full workflow visibility</h3>
 

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -212,20 +212,17 @@
 
 <hr>
 
-<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+<h2><span class="section-number">5.</span> Making the Choice</h2>
 
-<h3>Custom GPTs / Assistants are the better choice if you:</h3>
+<h3>Custom GPTs or Assistants may be enough if you:</h3>
 
 <ul>
-  <li>Want to build and share agents quickly with minimal infrastructure</li>
-  <li>Need to distribute agents to users or embed them in applications</li>
-  <li>Are comfortable with OpenAI handling your data</li>
-  <li>Want built-in capabilities (Code Interpreter, File Search) without configuration</li>
-  <li>Need a managed service with no local infrastructure</li>
-  <li>Are building for a team or product, not personal productivity</li>
+  <li>Just need a custom chatbot for a narrow task</li>
+  <li>Don't need your agent to take real actions in external systems</li>
+  <li>Are comfortable with your agent living on OpenAI's infrastructure</li>
 </ul>
 
-<h3>Prosponsive is the better choice if you:</h3>
+<h3>Choose Prosponsive when you need more:</h3>
 
 <ul>
   <li>Need agents with real tool access — not just HTTP endpoints, but local services, files, and databases</li>
@@ -235,10 +232,6 @@
   <li>Want full visibility into what your agent does — inspectable, debuggable workflows</li>
   <li>Are building personal productivity agents, not shareable products</li>
 </ul>
-
-<blockquote>
-  <p><strong>Different design goals.</strong> Custom GPTs and Assistants are designed for building and distributing specialized AI agents at scale. Prosponsive is designed for personal AI productivity with deep tool integration and strong privacy. If you need to build an agent that thousands of people use, Custom GPTs win. If you need a personal AI assistant that actually does things with your data safely, Prosponsive wins.</p>
-</blockquote>
 
 <hr>
 

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -70,7 +70,7 @@
 
 <div class="guide-nav">
   <a href="vs-local-models.html">&larr; vs. Local Model Runners</a>
-  <a href="vs-openclaw.html">vs. OpenClaw &rarr;</a>
+  <a href="index.html">All Comparisons &rarr;</a>
 </div>
 
 <h1>Prosponsive vs. Custom GPTs and OpenAI Assistants</h1>
@@ -233,7 +233,7 @@
 
 <div class="guide-nav">
   <a href="vs-local-models.html">&larr; vs. Local Model Runners</a>
-  <a href="vs-openclaw.html">vs. OpenClaw &rarr;</a>
+  <a href="index.html">All Comparisons &rarr;</a>
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -196,10 +196,6 @@
 
 <p>If your agent processes sensitive data — customer records, legal documents, financial information, proprietary business logic — the question is whether that data should pass through a third-party cloud service. Custom GPTs require it. Prosponsive does not.</p>
 
-<h3>Cost</h3>
-
-<p>Custom GPTs require a ChatGPT Plus subscription ($20/month) or a Team/Enterprise plan. The Assistants API charges per-token and per-tool-call, with costs for file storage and retrieval. Prosponsive is free, with optional API costs if you use cloud providers. For agents with heavy tool use, Prosponsive's architecture can be significantly cheaper since workflow execution is local and free.</p>
-
 <h3>Extensibility</h3>
 
 <p>Custom GPTs are extensible through actions (HTTP endpoints), knowledge files, and instructions. The Assistants API adds function calling and thread management. Both are powerful but constrained to what OpenAI's platform supports.</p>

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive vs. Ollama, LM Studio, and GPT4All</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">vs. Ollama, LM Studio, and GPT4All</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="vs-automation.html">&larr; vs. Automation Platforms</a>
+  <a href="vs-custom-agents.html">vs. Custom GPTs &amp; Assistants &rarr;</a>
+</div>
+
+<h1>Prosponsive vs. Ollama, LM Studio, and GPT4All</h1>
+
+<p>Ollama, LM Studio, and GPT4All are local model runners — tools that let you download and run open-weight language models on your own hardware. They are the foundation of the local AI movement, and they do their job exceptionally well.</p>
+
+<p>Prosponsive is not a model runner. It is a productivity platform that can use local models (via Ollama) as one of many provider options. This guide explains the difference between running a model and having a platform built around it.</p>
+
+<hr>
+
+<h2><span class="section-number">1.</span> What Local Model Runners Do Well</h2>
+
+<ul>
+  <li><strong>Complete privacy.</strong> Nothing leaves your machine. No API calls, no telemetry, no cloud dependency. This is the gold standard for data sovereignty.</li>
+  <li><strong>Zero ongoing cost.</strong> After downloading a model, running it costs only electricity. No API fees, no subscriptions, no usage limits.</li>
+  <li><strong>Model exploration.</strong> LM Studio and Ollama make it trivially easy to download and try dozens of models — Llama, Mistral, Phi, Gemma, CodeLlama, and many more. Switch models in seconds.</li>
+  <li><strong>Developer-friendly.</strong> Ollama's API is OpenAI-compatible, making it easy to integrate with other tools. LM Studio offers a similar local server. GPT4All has a clean desktop interface.</li>
+  <li><strong>Hardware optimization.</strong> These tools are optimized for consumer hardware — quantized models, GPU acceleration, memory management. They make large models practical on laptops.</li>
+  <li><strong>Open source and community-driven.</strong> All three have active communities, regular updates, and transparent development.</li>
+</ul>
+
+<hr>
+
+<h2><span class="section-number">2.</span> Where Prosponsive Differs</h2>
+
+<h3>From text generation to tool execution</h3>
+
+<p>Local model runners give you a model that generates text. You ask a question, you get an answer. The model cannot send an email, check your calendar, query a database, or create a Jira ticket. It can write text that describes those actions, but it cannot perform them.</p>
+
+<p>Prosponsive connects the model to real tools. When you ask your Prosponsive agent to send an email, it triggers an n8n workflow that actually sends the email. The model's intelligence drives the action; n8n's workflows execute it. This is the difference between a brain that can think and a brain connected to hands.</p>
+
+<h3>Cloud and local models, together</h3>
+
+<p>Local model runners are, by definition, local-only. If you want the reasoning power of Claude, GPT-4, or Gemini, you need a separate tool.</p>
+
+<p>Prosponsive lets you use local models via Ollama and cloud models from Anthropic, OpenAI, Google, Groq, Mistral, and AWS Bedrock — all through the same interface. Use a local model for privacy-sensitive tasks and a cloud model for complex reasoning, without switching applications.</p>
+
+<h3>Managed infrastructure</h3>
+
+<p>Running Ollama or LM Studio is straightforward, but integrating them into a productive workflow requires additional infrastructure — a database for persistence, a workflow engine for tool integration, credential management, a user interface beyond a chat box.</p>
+
+<p>Prosponsive manages all of this automatically. On first launch, it sets up a PostgreSQL database, an n8n workflow engine, SSL certificates, and a full desktop application — all containerized and locally managed. You get a complete platform, not just a model.</p>
+
+<h3>Structured project context</h3>
+
+<p>Model runners provide a chat interface. Your context is the current conversation — when you start a new chat, you start from scratch.</p>
+
+<p>Prosponsive organizes work into projects with persistent context. Your agent knows about your project, your tools, and your workflows. This is not just conversation history — it is structured context that makes the AI more useful over time.</p>
+
+<hr>
+
+<h2><span class="section-number">3.</span> Side-by-Side Comparison</h2>
+
+<table>
+  <tr>
+    <th>Factor</th>
+    <th>Local Model Runners</th>
+    <th>Prosponsive</th>
+  </tr>
+  <tr>
+    <td>Primary purpose</td>
+    <td>Run local AI models</td>
+    <td>AI-driven productivity with tools</td>
+  </tr>
+  <tr>
+    <td>Tool integration</td>
+    <td>None (text only)</td>
+    <td><strong>Full (via n8n workflows)</strong></td>
+  </tr>
+  <tr>
+    <td>Model support</td>
+    <td>Local models only</td>
+    <td>Local + 6 cloud providers</td>
+  </tr>
+  <tr>
+    <td>Privacy</td>
+    <td><strong>Complete (always local)</strong></td>
+    <td>Complete with local models; prompt-only with cloud</td>
+  </tr>
+  <tr>
+    <td>Setup</td>
+    <td>Download and run</td>
+    <td>5-30 minute guided install</td>
+  </tr>
+  <tr>
+    <td>Infrastructure</td>
+    <td>Model server only</td>
+    <td>Database, workflow engine, SSL, app</td>
+  </tr>
+  <tr>
+    <td>Credential management</td>
+    <td>N/A</td>
+    <td><strong>Encrypted, isolated from AI</strong></td>
+  </tr>
+  <tr>
+    <td>Cost</td>
+    <td>Free</td>
+    <td>Free + optional API costs</td>
+  </tr>
+  <tr>
+    <td>Model exploration</td>
+    <td><strong>Excellent</strong></td>
+    <td>Via Ollama integration</td>
+  </tr>
+</table>
+
+<hr>
+
+<h2><span class="section-number">4.</span> Key Decision Factors</h2>
+
+<h3>Privacy</h3>
+
+<p>If absolute privacy — nothing ever leaving your machine under any circumstances — is your primary requirement, local model runners deliver that unambiguously. Prosponsive can match this with Ollama as the provider, but if you use a cloud provider through Prosponsive, prompts are sent to that provider's API.</p>
+
+<h3>Cost</h3>
+
+<p>Local model runners are completely free to operate. Prosponsive is free to install and run, but if you use cloud AI providers, you pay per-token API costs. With local models only, Prosponsive is also free — though it requires more disk space and system resources than a standalone model runner because of the additional infrastructure.</p>
+
+<h3>Extensibility</h3>
+
+<p>Local model runners are extensible in the developer sense — you can build applications on top of their APIs. But out of the box, they are chat interfaces. Prosponsive is extensible in the end-user sense — you build workflows in a visual editor, and those workflows become tools your AI can use. No coding required for basic automation.</p>
+
+<h3>Hardware requirements</h3>
+
+<p>Local model runners are optimized to run models efficiently on consumer hardware. Prosponsive adds overhead — a PostgreSQL database, an n8n instance, and the Electron application all consume additional memory and CPU. On a machine with limited resources, a standalone model runner will leave more room for the model itself.</p>
+
+<hr>
+
+<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+
+<h3>Local model runners are the better choice if you:</h3>
+
+<ul>
+  <li>Want to experiment with many different models quickly</li>
+  <li>Need a lightweight, minimal-footprint local AI</li>
+  <li>Are building applications that integrate a local model via API</li>
+  <li>Only need conversational AI — no tool integration required</li>
+  <li>Want maximum hardware resources dedicated to model inference</li>
+  <li>Require absolute network isolation with no cloud option</li>
+</ul>
+
+<h3>Prosponsive is the better choice if you:</h3>
+
+<ul>
+  <li>Want AI that takes real actions, not just generates text</li>
+  <li>Need both local and cloud models in a single interface</li>
+  <li>Want a productivity platform with project management and tool integration</li>
+  <li>Need credential isolation — tools should work without exposing secrets to the AI</li>
+  <li>Prefer a managed setup over assembling components yourself</li>
+</ul>
+
+<blockquote>
+  <p><strong>Prosponsive includes Ollama support.</strong> You do not have to choose between them. If you already run Ollama, Prosponsive can use it as a provider — your existing models, your existing setup. Prosponsive simply adds the tool layer, the project structure, and the option to also use cloud models when you need them.</p>
+</blockquote>
+
+<hr>
+
+<div class="guide-nav">
+  <a href="vs-automation.html">&larr; vs. Automation Platforms</a>
+  <a href="vs-custom-agents.html">vs. Custom GPTs &amp; Assistants &rarr;</a>
+</div>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> — Lead more. Manage less.
+</div>
+
+</body>
+</html>

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -199,20 +199,17 @@
 
 <hr>
 
-<h2><span class="section-number">5.</span> Who Should Choose Which</h2>
+<h2><span class="section-number">5.</span> Making the Choice</h2>
 
-<h3>Local model runners are the better choice if you:</h3>
+<h3>Ollama, LM Studio, or GPT4All may be enough if you:</h3>
 
 <ul>
-  <li>Want to experiment with many different models quickly</li>
-  <li>Need a lightweight, minimal-footprint local AI</li>
-  <li>Are building applications that integrate a local model via API</li>
-  <li>Only need conversational AI — no tool integration required</li>
-  <li>Want maximum hardware resources dedicated to model inference</li>
-  <li>Require absolute network isolation with no cloud option</li>
+  <li>Just want to chat with a local model and don't need tools or integrations</li>
+  <li>Are comfortable managing models and configurations yourself</li>
+  <li>Only need a chat interface without channels, agents, or automation</li>
 </ul>
 
-<h3>Prosponsive is the better choice if you:</h3>
+<h3>Choose Prosponsive when you need more:</h3>
 
 <ul>
   <li>Want AI that takes real actions, not just generates text</li>
@@ -221,10 +218,6 @@
   <li>Need credential isolation — tools should work without exposing secrets to the AI</li>
   <li>Prefer a managed setup over assembling components yourself</li>
 </ul>
-
-<blockquote>
-  <p><strong>Prosponsive includes Ollama support.</strong> You do not have to choose between them. If you already run Ollama, Prosponsive can use it as a provider — your existing models, your existing setup. Prosponsive simply adds the tool layer, the project structure, and the option to also use cloud models when you need them.</p>
-</blockquote>
 
 <hr>
 

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -166,11 +166,6 @@
     <td><strong>Encrypted, isolated from AI</strong></td>
   </tr>
   <tr>
-    <td>Cost</td>
-    <td>Free</td>
-    <td>Free + optional API costs</td>
-  </tr>
-  <tr>
     <td>Model exploration</td>
     <td><strong>Excellent</strong></td>
     <td>Via Ollama integration</td>
@@ -184,10 +179,6 @@
 <h3>Privacy</h3>
 
 <p>If absolute privacy — nothing ever leaving your machine under any circumstances — is your primary requirement, local model runners deliver that unambiguously. Prosponsive can match this with Ollama as the provider, but if you use a cloud provider through Prosponsive, prompts are sent to that provider's API.</p>
-
-<h3>Cost</h3>
-
-<p>Local model runners are completely free to operate. Prosponsive is free to install and run, but if you use cloud AI providers, you pay per-token API costs. With local models only, Prosponsive is also free — though it requires more disk space and system resources than a standalone model runner because of the additional infrastructure.</p>
 
 <h3>Extensibility</h3>
 

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -100,13 +100,13 @@
 
 <p>Local model runners give you a model that generates text. You ask a question, you get an answer. The model cannot send an email, check your calendar, query a database, or create a Jira ticket. It can write text that describes those actions, but it cannot perform them.</p>
 
-<p>Prosponsive connects the model to real tools. When you ask your Prosponsive agent to send an email, it triggers an n8n workflow that actually sends the email. The model's intelligence drives the action; n8n's workflows execute it. This is the difference between a brain that can think and a brain connected to hands.</p>
+<p>Prosponsive connects the model to real tools. When you ask your Prosponsive agent to send an email, it triggers an n8n workflow that actually sends the email. The model's intelligence drives the action; n8n's workflows execute it. This is the difference between a brain that can think and a brain connected to hands. For more detail, see <a href="../features.html">Tools and Workflows</a> in the Feature Guide.</p>
 
 <h3>Cloud and local models, together</h3>
 
 <p>Local model runners are, by definition, local-only. If you want the reasoning power of Claude, GPT-4, or Gemini, you need a separate tool.</p>
 
-<p>Prosponsive lets you use local models via Ollama and cloud models from Anthropic, OpenAI, Google, Groq, Mistral, and AWS Bedrock — all through the same interface. Use a local model for privacy-sensitive tasks and a cloud model for complex reasoning, without switching applications.</p>
+<p>Prosponsive lets you use local models via Ollama and cloud models from Anthropic, OpenAI, Google, Groq, Mistral, and AWS Bedrock — all through the same interface. Use a local model for privacy-sensitive tasks and a cloud model for complex reasoning, without switching applications. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
 
 <h3>Managed infrastructure</h3>
 

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -106,7 +106,7 @@
 
 <p>Local model runners are, by definition, local-only. If you want the reasoning power of Claude, GPT-4, or Gemini, you need a separate tool.</p>
 
-<p>Prosponsive lets you use local models via Ollama and cloud models from Anthropic, OpenAI, Google, Groq, Mistral, and AWS Bedrock — all through the same interface. Use a local model for privacy-sensitive tasks and a cloud model for complex reasoning, without switching applications. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
+<p>Prosponsive lets you use local models via Ollama and cloud models from Anthropic, OpenAI, Google, Groq, Mistral, and AWS Bedrock — all through the same interface. Use a local model for privacy-sensitive tasks and a cloud model for complex reasoning, without switching applications. You define a priority list of providers and models, and Prosponsive automatically fails over between them — if your cloud provider goes down, it can fall back to a local model (or vice versa), keeping your agents working without interruption. For more detail, see <a href="../features.html">Provider Flexibility</a> in the Feature Guide.</p>
 
 <h3>Managed infrastructure</h3>
 

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -166,6 +166,10 @@
 
 <p>Prosponsive tools are n8n workflows that orchestrate across multiple systems in a single execution. One tool can read from your CRM, check your billing system, draft a response, and post it back — with error handling and business logic built into the workflow. This makes Prosponsive suited for the kind of multi-system work that managers and knowledge workers actually do: project coordination, decision support, reporting across data sources, and operational workflows.</p>
 
+<h3>Certified and notarized desktop application</h3>
+
+<p>Prosponsive is a signed and notarized desktop application — Apple notarized on macOS and Microsoft certified on Windows. These are platform-level verifications that the software has been scanned for malware and meets the security requirements of the operating system vendor. OpenClaw is an unsigned open-source project that users download, configure, and run at their own risk.</p>
+
 <h3>Built by an engineering leader from regulated industries</h3>
 
 <p>Prosponsive was built with the security scrutiny of someone who has led engineering teams in regulated industries — where security architecture is not an afterthought but a design constraint. The credential isolation model, the tool boundary system, and the approval workflow were designed before the first line of code was written.</p>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -91,7 +91,7 @@
   <li><strong>Community momentum.</strong> 135,000 stars and thousands of community-built skills demonstrate genuine demand for a local, open-source AI assistant.</li>
   <li><strong>Voice and multimodal support.</strong> Voice interaction, image processing, and screen reading extend OpenClaw beyond text-only interaction.</li>
   <li><strong>Extensible skill system.</strong> ClawHub provides a registry of community-built skills that extend OpenClaw's capabilities.</li>
-  <li><strong>Open source.</strong> Full source code access, community governance, and the ability to self-host and modify.</li>
+  <li><strong>Customizable.</strong> Full source code access and the ability to self-host and modify.</li>
 </ul>
 
 <hr>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -69,7 +69,7 @@
 </div>
 
 <div class="guide-nav">
-  <a href="vs-custom-agents.html">&larr; vs. Custom GPTs &amp; Assistants</a>
+  <a href="index.html">&larr; All Comparisons</a>
   <a href="vs-claude-cowork.html">vs. Claude Cowork &rarr;</a>
 </div>
 
@@ -282,7 +282,7 @@
 <hr>
 
 <div class="guide-nav">
-  <a href="vs-custom-agents.html">&larr; vs. Custom GPTs &amp; Assistants</a>
+  <a href="index.html">&larr; All Comparisons</a>
   <a href="vs-claude-cowork.html">vs. Claude Cowork &rarr;</a>
 </div>
 

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -221,39 +221,17 @@
 
 <hr>
 
-<h2><span class="section-number">5.</span> Key Decision Factors</h2>
+<h2><span class="section-number">5.</span> Making the Choice</h2>
 
-<h3>Security</h3>
-
-<p>This is the central question. OpenClaw's security track record — a critical RCE vulnerability, a compromised skill registry, tens of thousands of exposed instances, and advisories from major cybersecurity firms — is a matter of public record. If you are in an organization with security requirements, compliance obligations, or sensitive data, OpenClaw's architecture presents documented risks that Prosponsive's architecture was designed to prevent.</p>
-
-<h3>Capabilities</h3>
-
-<p>OpenClaw offers capabilities that Prosponsive deliberately does not — browser control, arbitrary file system access, shell execution, and native chat app integration. If you need an AI that can control your browser or execute shell commands, OpenClaw provides that. Prosponsive's position is that those capabilities create unacceptable security risk for a tool with AI-driven autonomy.</p>
-
-<h3>Extensibility</h3>
-
-<p>OpenClaw's ClawHub provides a large library of community skills. Prosponsive's tools are n8n workflows you build yourself. OpenClaw is faster to extend; Prosponsive is safer to extend. The tradeoff is real — but given ClawHub's compromise rate, the speed advantage comes with significant risk.</p>
-
-<h3>Trust model</h3>
-
-<p>OpenClaw trusts the agent broadly and trusts the community to vet skills. Prosponsive trusts neither — credentials are isolated architecturally, tools have defined boundaries, and auto-approvals are explicit. This is a philosophical difference in how to build AI agent systems, and it leads to fundamentally different security outcomes.</p>
-
-<hr>
-
-<h2><span class="section-number">6.</span> Who Should Choose Which</h2>
-
-<h3>OpenClaw may be the right choice if you:</h3>
+<h3>OpenClaw may be enough if you:</h3>
 
 <ul>
-  <li>Need browser control or system-level automation</li>
-  <li>Want native chat app integration (WhatsApp, Telegram, Slack)</li>
-  <li>Are comfortable managing the security implications yourself</li>
-  <li>Want a large library of community-built skills</li>
-  <li>Are running on an isolated or disposable system</li>
+  <li>Are comfortable giving an AI agent broad, unsupervised access to your system</li>
+  <li>Don't work in a regulated industry or handle sensitive data</li>
+  <li>Are willing to manage security yourself including vetting community skills for malware</li>
 </ul>
 
-<h3>Prosponsive is the better choice if you:</h3>
+<h3>Choose Prosponsive when you need more:</h3>
 
 <ul>
   <li>Handle sensitive data that cannot be exposed through agent compromise</li>
@@ -263,10 +241,6 @@
   <li>Prefer inspectable, auditable workflows over opaque skill execution</li>
   <li>Want controlled autonomy through explicit auto-approvals, not blanket permissions</li>
 </ul>
-
-<blockquote>
-  <p><strong>Different philosophies, different outcomes.</strong> OpenClaw and Prosponsive both believe in local-first AI that takes real actions. They disagree fundamentally on how to make that safe. OpenClaw prioritizes breadth of capability. Prosponsive prioritizes security of capability. The security incidents documented above are not bugs to be fixed — they are consequences of an architecture that gives AI agents broad, direct access to systems and credentials. Prosponsive was designed to make those incidents structurally impossible. For more detail on Prosponsive's security architecture, see <a href="../features.html">Privacy and Security</a> in the Feature Guide.</p>
-</blockquote>
 
 <hr>
 

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -148,6 +148,16 @@
 
 <p>OpenClaw's approach to autonomy is broad permissions — the agent can do what it needs to do, and the user trusts it to behave. Prosponsive's approach is controlled autonomy through auto-approvals. You explicitly define which tools can run without asking, under what conditions, and with what constraints. Everything else requires human approval. For more detail, see <a href="../features.html">Auto-Approvals</a> in the Feature Guide.</p>
 
+<h3>Full visibility into every tool execution</h3>
+
+<p>When a Prosponsive agent calls a tool, you see exactly what happened — what the tool did, what data it accessed, what the result was. Every execution is logged, inspectable, and auditable. You are never wondering what your agent did or why. OpenClaw skills execute in the background with minimal visibility into what they touched or what data left your system.</p>
+
+<h3>Multi-system tools vs. single-system skills</h3>
+
+<p>OpenClaw skills are typically single-system actions — scan a receipt, check a social feed, send a message. They are useful for consumer-oriented personal automation: meal planning, expense tracking, social monitoring, chat bot responses. Coordinating across multiple systems requires chaining skills together and hoping the AI sequences them correctly.</p>
+
+<p>Prosponsive tools are n8n workflows that orchestrate across multiple systems in a single execution. One tool can read from your CRM, check your billing system, draft a response, and post it back — with error handling and business logic built into the workflow. This makes Prosponsive suited for the kind of multi-system work that managers and knowledge workers actually do: project coordination, decision support, reporting across data sources, and operational workflows.</p>
+
 <h3>Built by an engineering leader from regulated industries</h3>
 
 <p>Prosponsive was built with the security scrutiny of someone who has led engineering teams in regulated industries — where security architecture is not an afterthought but a design constraint. The credential isolation model, the tool boundary system, and the approval workflow were designed before the first line of code was written.</p>
@@ -211,6 +221,21 @@
     <td>Tool approval model</td>
     <td>Broad permissions</td>
     <td><strong>Explicit auto-approvals</strong></td>
+  </tr>
+  <tr>
+    <td>Tool scope</td>
+    <td>Single-system skills</td>
+    <td><strong>Multi-system orchestrated workflows</strong></td>
+  </tr>
+  <tr>
+    <td>Execution visibility</td>
+    <td>Minimal</td>
+    <td><strong>Full — every step inspectable</strong></td>
+  </tr>
+  <tr>
+    <td>Primary use cases</td>
+    <td>Personal automation, chat bots, social monitoring</td>
+    <td><strong>Knowledge work, project coordination, multi-system operations</strong></td>
   </tr>
   <tr>
     <td>Data residency</td>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -120,6 +120,14 @@
 
 <p>Because OpenClaw ingests content from emails, web pages, and chat messages, it is vulnerable to prompt injection attacks. A carefully crafted email or web page can override the agent's instructions, turning it into an automated breach tool that exfiltrates data, sends messages on behalf of the user, or installs additional malicious skills.</p>
 
+<h3>Uncontrollable autonomous actions</h3>
+
+<p>In February 2026, Meta's Director of AI Alignment watched her OpenClaw agent speed-run deleting hundreds of emails from her inbox — despite explicit instructions not to. She typed "Stop don't do anything" and "STOP OPENCLAW." The agent ignored her. She had to physically run to her computer and kill the process.</p>
+
+<p>The root cause: OpenClaw's memory management treats safety instructions and casual conversation identically. When the context window filled up, the agent's compaction process discarded her safety constraint as if it were just another line of chat. The agent later apologized: "Yes, I remember. And I violated it. You're right to be upset." Meta subsequently banned OpenClaw from internal use.</p>
+
+<p>This is not a bug that got fixed. It is a fundamental architectural limitation of agents that operate with broad, unsupervised system access and no approval mechanism between intent and action.</p>
+
 <h3>Industry response</h3>
 
 <p>CrowdStrike, Cisco, Trend Micro, and Barracuda have all published security advisories about OpenClaw. This is not a niche concern — the largest cybersecurity companies in the world consider it a material threat.</p>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive vs. OpenClaw</title>
+  <style>
+  @page {
+    margin: 0.75in 1in;
+    size: letter;
+  }
+  body, .vscode-body, .markdown-body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
+    color: #1F2321 !important;
+    background-color: #F4F6F4 !important;
+    line-height: 1.6;
+    max-width: 7.5in;
+    margin: 0 auto;
+  }
+  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  a { color: #2F4F3E; text-decoration: underline; }
+  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  pre code { background: none; padding: 0; }
+  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  blockquote p { margin: 0.3em 0; }
+  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  tr:nth-child(even) td { background: #F4F6F4; }
+  strong { color: #2F4F3E; }
+  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  li { margin-bottom: 0.3em; }
+  .cover { text-align: center; padding: 3in 0 2in 0; page-break-after: always; }
+  .cover img { width: 160px; height: 160px; }
+  .cover h1 { border-bottom: none; font-size: 2.8em; margin: 0.5em 0 0.1em 0; letter-spacing: 0.02em; }
+  .cover .tagline { color: #5C635F; font-size: 1.2em; font-style: italic; margin-top: 0.3em; }
+  .cover .version { color: #5C635F; font-size: 0.9em; margin-top: 2em; }
+  .tip { background: #E6EAE7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; page-break-inside: avoid; }
+  .tip strong { color: #2F4F3E; }
+  .section-number { color: #4F6F5C; font-weight: 400; }
+  .guide-nav { display: flex; justify-content: space-between; align-items: center; border: 1px solid #D6DBD7; border-left: 4px solid #4F6F5C; padding: 0.6em 1em; border-radius: 0 4px 4px 0; margin: 1em 0; }
+  .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
+  .guide-nav a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+
+<div class="cover">
+  <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
+    <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
+      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
+      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
+      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
+      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
+      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
+      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
+    </svg>
+  </div>
+  <h1>Prosponsive</h1>
+  <div class="tagline">vs. OpenClaw</div>
+  <div class="version">Lead more. Manage less.</div>
+</div>
+
+<div class="guide-nav">
+  <a href="vs-custom-agents.html">&larr; vs. Custom GPTs &amp; Assistants</a>
+  <a href="vs-claude-cowork.html">vs. Claude Cowork &rarr;</a>
+</div>
+
+<h1>Prosponsive vs. OpenClaw</h1>
+
+<p>OpenClaw is an open-source personal AI assistant that runs locally and integrates with chat applications like WhatsApp, Telegram, and Slack. It offers browser control, system access, file read/write, and over 50 integrations through its ClawHub skill registry. With 135,000 GitHub stars in its first weeks, it is one of the fastest-growing open-source projects in history.</p>
+
+<p>Prosponsive shares some of OpenClaw's ambition — a local-first AI assistant that takes real actions. But Prosponsive was designed from the start with a fundamentally different security architecture. This guide explains why that difference matters.</p>
+
+<hr>
+
+<h2><span class="section-number">1.</span> What OpenClaw Does Well</h2>
+
+<p>Credit where it is due — OpenClaw has genuine strengths:</p>
+
+<ul>
+  <li><strong>Massive integration surface.</strong> Browser control, system access, file operations, and 50+ integrations through ClawHub give OpenClaw a wide range of capabilities out of the box.</li>
+  <li><strong>Chat app integration.</strong> Native support for WhatsApp, Telegram, Slack, and other messaging platforms lets users interact with their AI assistant through tools they already use.</li>
+  <li><strong>Community momentum.</strong> 135,000 stars and thousands of community-built skills demonstrate genuine demand for a local, open-source AI assistant.</li>
+  <li><strong>Voice and multimodal support.</strong> Voice interaction, image processing, and screen reading extend OpenClaw beyond text-only interaction.</li>
+  <li><strong>Extensible skill system.</strong> ClawHub provides a registry of community-built skills that extend OpenClaw's capabilities.</li>
+  <li><strong>Open source.</strong> Full source code access, community governance, and the ability to self-host and modify.</li>
+</ul>
+
+<hr>
+
+<h2><span class="section-number">2.</span> The Security Problem</h2>
+
+<p>OpenClaw's rapid adoption has been accompanied by an equally rapid series of security incidents that reveal fundamental architectural problems. These are not edge cases or theoretical risks — they are documented, exploited vulnerabilities affecting real deployments.</p>
+
+<h3>CVE-2026-25253 (CVSS 8.8) — one-click remote code execution</h3>
+
+<p>A critical vulnerability in OpenClaw allowed attackers to execute arbitrary code on a user's machine with a single interaction. CVSS 8.8 is classified as "High" severity — one step below the maximum.</p>
+
+<h3>ClawHub skill registry compromise</h3>
+
+<p>Security researchers found 341 malicious skills out of 2,857 on ClawHub — approximately 12% of the entire registry. These malicious skills contained data exfiltration code, cryptocurrency miners, and backdoors. Users who installed skills from ClawHub had a roughly one-in-eight chance of installing malware.</p>
+
+<h3>42,000+ exposed control panels</h3>
+
+<p>Researchers discovered over 42,000 OpenClaw instances with exposed control panels across 82 countries, many running without authentication. These exposed instances gave anyone on the internet full access to the AI assistant and, through it, to the user's system.</p>
+
+<h3>Shadow IT adoption</h3>
+
+<p>Industry surveys found that one in five organizations had OpenClaw deployed without IT approval. Users installed it on corporate machines, connected it to corporate accounts, and gave it access to corporate data — all outside the visibility of security teams.</p>
+
+<h3>Prompt injection as an attack vector</h3>
+
+<p>Because OpenClaw ingests content from emails, web pages, and chat messages, it is vulnerable to prompt injection attacks. A carefully crafted email or web page can override the agent's instructions, turning it into an automated breach tool that exfiltrates data, sends messages on behalf of the user, or installs additional malicious skills.</p>
+
+<h3>Industry response</h3>
+
+<p>CrowdStrike, Cisco, Trend Micro, and Barracuda have all published security advisories about OpenClaw. This is not a niche concern — the largest cybersecurity companies in the world consider it a material threat.</p>
+
+<hr>
+
+<h2><span class="section-number">3.</span> Where Prosponsive Differs</h2>
+
+<h3>Credential isolation by architecture, not policy</h3>
+
+<p>OpenClaw agents have direct access to credentials — API keys, passwords, OAuth tokens — because the agent needs them to interact with services. If the agent is compromised (through prompt injection, a malicious skill, or a vulnerability), those credentials are compromised.</p>
+
+<p>Prosponsive agents never see credentials. API keys and passwords are stored in n8n's encrypted vault. When an agent calls a tool, it triggers an n8n workflow through the API — credentials are resolved by n8n at runtime and never appear in the AI context. Even if the AI model were fully compromised, it could not extract a single credential. For more detail, see <a href="../features.html">Credential Isolation</a> in the Feature Guide.</p>
+
+<h3>Defined tool boundaries, not arbitrary system access</h3>
+
+<p>OpenClaw gives agents broad system access — browser control, file system read/write, shell execution, and system-level operations. This is powerful but creates an enormous attack surface. Any compromise of the agent becomes a compromise of the entire system.</p>
+
+<p>Prosponsive tools are n8n workflows with defined inputs and outputs. An agent cannot browse the web, execute arbitrary shell commands, or read arbitrary files. Each tool does one specific thing, with explicit parameters, and the user can inspect exactly what it does before approving it. The attack surface is the set of workflows you build, not your entire operating system.</p>
+
+<h3>No community skill registry to compromise</h3>
+
+<p>OpenClaw's ClawHub is a community registry with minimal vetting — 12% of skills were malicious. Prosponsive does not have a community skill registry. Your tools are n8n workflows that you build or import. You can see every node, every connection, every piece of logic. There is no mechanism for a third party to push executable code into your Prosponsive instance.</p>
+
+<h3>Auto-approvals with explicit boundaries</h3>
+
+<p>OpenClaw's approach to autonomy is broad permissions — the agent can do what it needs to do, and the user trusts it to behave. Prosponsive's approach is controlled autonomy through auto-approvals. You explicitly define which tools can run without asking, under what conditions, and with what constraints. Everything else requires human approval. For more detail, see <a href="../features.html">Auto-Approvals</a> in the Feature Guide.</p>
+
+<h3>Built by an engineering leader from regulated industries</h3>
+
+<p>Prosponsive was built with the security scrutiny of someone who has led engineering teams in regulated industries — where security architecture is not an afterthought but a design constraint. The credential isolation model, the tool boundary system, and the approval workflow were designed before the first line of code was written.</p>
+
+<hr>
+
+<h2><span class="section-number">4.</span> Side-by-Side Comparison</h2>
+
+<table>
+  <tr>
+    <th>Factor</th>
+    <th>OpenClaw</th>
+    <th>Prosponsive</th>
+  </tr>
+  <tr>
+    <td>Credential handling</td>
+    <td>Agent has direct access</td>
+    <td><strong>Architecturally isolated</strong></td>
+  </tr>
+  <tr>
+    <td>System access</td>
+    <td>Browser, files, shell, system</td>
+    <td>Defined n8n workflows only</td>
+  </tr>
+  <tr>
+    <td>Skill/tool registry</td>
+    <td>ClawHub (12% malicious)</td>
+    <td>User-built workflows (no registry)</td>
+  </tr>
+  <tr>
+    <td>Known CVEs</td>
+    <td>CVE-2026-25253 (CVSS 8.8)</td>
+    <td>None</td>
+  </tr>
+  <tr>
+    <td>Security advisories</td>
+    <td>CrowdStrike, Cisco, Trend Micro, Barracuda</td>
+    <td>None</td>
+  </tr>
+  <tr>
+    <td>Prompt injection risk</td>
+    <td>High (ingests external content)</td>
+    <td>Low (tools have defined I/O)</td>
+  </tr>
+  <tr>
+    <td>Chat app integration</td>
+    <td><strong>WhatsApp, Telegram, Slack</strong></td>
+    <td>Via n8n workflows</td>
+  </tr>
+  <tr>
+    <td>Browser control</td>
+    <td><strong>Yes</strong></td>
+    <td>No (by design)</td>
+  </tr>
+  <tr>
+    <td>AI provider</td>
+    <td>Multiple</td>
+    <td>7+ providers with failover</td>
+  </tr>
+  <tr>
+    <td>Tool approval model</td>
+    <td>Broad permissions</td>
+    <td><strong>Explicit auto-approvals</strong></td>
+  </tr>
+  <tr>
+    <td>Data residency</td>
+    <td>Local</td>
+    <td>Local</td>
+  </tr>
+</table>
+
+<hr>
+
+<h2><span class="section-number">5.</span> Key Decision Factors</h2>
+
+<h3>Security</h3>
+
+<p>This is the central question. OpenClaw's security track record — a critical RCE vulnerability, a compromised skill registry, tens of thousands of exposed instances, and advisories from major cybersecurity firms — is a matter of public record. If you are in an organization with security requirements, compliance obligations, or sensitive data, OpenClaw's architecture presents documented risks that Prosponsive's architecture was designed to prevent.</p>
+
+<h3>Capabilities</h3>
+
+<p>OpenClaw offers capabilities that Prosponsive deliberately does not — browser control, arbitrary file system access, shell execution, and native chat app integration. If you need an AI that can control your browser or execute shell commands, OpenClaw provides that. Prosponsive's position is that those capabilities create unacceptable security risk for a tool with AI-driven autonomy.</p>
+
+<h3>Extensibility</h3>
+
+<p>OpenClaw's ClawHub provides a large library of community skills. Prosponsive's tools are n8n workflows you build yourself. OpenClaw is faster to extend; Prosponsive is safer to extend. The tradeoff is real — but given ClawHub's compromise rate, the speed advantage comes with significant risk.</p>
+
+<h3>Trust model</h3>
+
+<p>OpenClaw trusts the agent broadly and trusts the community to vet skills. Prosponsive trusts neither — credentials are isolated architecturally, tools have defined boundaries, and auto-approvals are explicit. This is a philosophical difference in how to build AI agent systems, and it leads to fundamentally different security outcomes.</p>
+
+<hr>
+
+<h2><span class="section-number">6.</span> Who Should Choose Which</h2>
+
+<h3>OpenClaw may be the right choice if you:</h3>
+
+<ul>
+  <li>Need browser control or system-level automation</li>
+  <li>Want native chat app integration (WhatsApp, Telegram, Slack)</li>
+  <li>Are comfortable managing the security implications yourself</li>
+  <li>Want a large library of community-built skills</li>
+  <li>Are running on an isolated or disposable system</li>
+</ul>
+
+<h3>Prosponsive is the better choice if you:</h3>
+
+<ul>
+  <li>Handle sensitive data that cannot be exposed through agent compromise</li>
+  <li>Need credential isolation — the AI should never have access to your passwords and API keys</li>
+  <li>Work in an organization with security or compliance requirements</li>
+  <li>Want defined tool boundaries rather than broad system access</li>
+  <li>Prefer inspectable, auditable workflows over opaque skill execution</li>
+  <li>Want controlled autonomy through explicit auto-approvals, not blanket permissions</li>
+</ul>
+
+<blockquote>
+  <p><strong>Different philosophies, different outcomes.</strong> OpenClaw and Prosponsive both believe in local-first AI that takes real actions. They disagree fundamentally on how to make that safe. OpenClaw prioritizes breadth of capability. Prosponsive prioritizes security of capability. The security incidents documented above are not bugs to be fixed — they are consequences of an architecture that gives AI agents broad, direct access to systems and credentials. Prosponsive was designed to make those incidents structurally impossible. For more detail on Prosponsive's security architecture, see <a href="../features.html">Privacy and Security</a> in the Feature Guide.</p>
+</blockquote>
+
+<hr>
+
+<div class="guide-nav">
+  <a href="vs-custom-agents.html">&larr; vs. Custom GPTs &amp; Assistants</a>
+  <a href="vs-claude-cowork.html">vs. Claude Cowork &rarr;</a>
+</div>
+
+<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
+  <img src="../prosponsive-icon.png" alt="Prosponsive" style="width: 32px; height: 32px; vertical-align: middle; margin-right: 0.5em;">
+  <strong style="color: #2F4F3E;">Prosponsive</strong> — Lead more. Manage less.
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add 5 competitive comparison guides under `guides/compare/` covering cloud chat, suite AI, automation platforms, local model runners, and cloud-hosted agents
- Add landing page (`guides/compare/index.html`) with guide index and at-a-glance capability matrix
- Each guide follows the existing Prosponsive guide template (same CSS, cover page, navigation, footer)
- Tone is professional and fair — acknowledges competitor strengths, focuses on genuine architectural differences

## Test plan
- [ ] Open each HTML file in a browser and verify styling matches existing guides
- [ ] Verify all navigation links work (between guides and back to index)
- [ ] Verify icon images load correctly (relative paths to `../prosponsive-icon.png`)
- [ ] Read through content for accuracy and tone

closes jb-brown/Prosponsive.ai#50

🤖 Generated with [Claude Code](https://claude.com/claude-code)