### PR TITLE
design(logo): strip legacy chat-bubble SVG overlay from guides

### DIFF
--- a/guides/basics.html
+++ b/guides/basics.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">Basics</div>

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -51,17 +51,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">Comparison Guides</div>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">vs. Zapier and Make</div>

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">vs. Claude Cowork</div>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">vs. ChatGPT, Claude.ai, and Gemini</div>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">vs. Microsoft Copilot and Google Workspace AI</div>

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">vs. Custom GPTs and OpenAI Assistants</div>

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">vs. Ollama, LM Studio, and GPT4All</div>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">vs. OpenClaw</div>

--- a/guides/email-assistant-example.html
+++ b/guides/email-assistant-example.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">Example: Email Assistant</div>

--- a/guides/features.html
+++ b/guides/features.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">Feature Guide</div>

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">Feedback &amp; Philosophy</div>

--- a/guides/install-guide.html
+++ b/guides/install-guide.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">Install Guide</div>

--- a/guides/n8n-tool-building-guide.html
+++ b/guides/n8n-tool-building-guide.html
@@ -44,17 +44,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">Building Tools with n8n</div>

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">Building Tools with n8n</div>

--- a/guides/user-guide.html
+++ b/guides/user-guide.html
@@ -47,17 +47,6 @@
 <div class="cover">
   <div style="position: relative; width: 200px; height: 200px; margin: 0 auto;">
     <img src="../assets/prosponsive-logo.svg" alt="Prosponsive" style="width: 120px; height: 120px; position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
-    <svg style="position: absolute; inset: 0; width: 100%; height: 100%;" viewBox="0 0 112 112" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <rect x="0" y="0" rx="8" ry="8" width="40" height="26" fill="#2F4F3E" />
-      <polygon points="30,26 38,36 32,26" fill="#2F4F3E" />
-      <line x1="8" y1="9" x2="32" y2="9" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="8" y1="17" x2="24" y2="17" stroke="#F4F6F4" stroke-width="2.5" stroke-linecap="round" />
-      <rect x="72" y="86" rx="8" ry="8" width="40" height="26" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" />
-      <polygon points="82,86 74,76 84,86" fill="#F4F6F4" stroke="#2F4F3E" stroke-width="2" stroke-linejoin="round" />
-      <line x1="81" y1="86" x2="85" y2="86" stroke="#F4F6F4" stroke-width="3" />
-      <line x1="80" y1="95" x2="104" y2="95" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-      <line x1="80" y1="103" x2="96" y2="103" stroke="#2F4F3E" stroke-width="2.5" stroke-linecap="round" />
-    </svg>
   </div>
   <h1>Prosponsive</h1>
   <div class="tagline">User Guide</div>


### PR DESCRIPTION
## Summary
- Removes the inline `<svg viewBox="0 0 112 112">` block (two chat bubbles flanking the old yin-yang logo) from all 16 guide pages.
- The bubbles paired with the old yin-yang mark; with the new P+sparkle they no longer make sense.
- Wrapper div and centered `<img>` are kept untouched.

## Test plan
- [ ] Open a few guide pages — confirm the cover area shows just the new logo, no leftover bubbles
- [ ] Confirm `index.html`, `releases/index.html`, and the legal pages were not affected (they didn't have the bubbles)

🤖 Generated with [Claude Code](https://claude.com/claude-code)