### PR TITLE
chore: add CodeQL workflow for JS analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,54 @@
+name: CodeQL
+
+# CodeQL static analysis for the Prosponsive.ai marketing site.
+#
+# Repo is ~95% HTML / ~3% JavaScript / ~2% CSS — only JavaScript is
+# meaningfully analyzable by CodeQL, so the matrix is JS-only.
+#
+# Runs on:
+#   - every PR targeting main (so vulns are caught at review time)
+#   - every push to main (so a regression on direct-push commits is caught)
+#   - weekly schedule (catches new CVE rules added to CodeQL upstream against
+#     code that hasn't changed but suddenly has a new known-vuln signature)
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '0 12 * * 1'  # Mondays at 12:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # Use the default + security-extended query suite for stronger coverage
+          # on a small attack surface.
+          queries: security-extended
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Adds GitHub-native code scanning (CodeQL) to this repo. Closes the only remaining code-scanning gap across the three Prosponsive repos.

## Why

Per the strategic-priorities refresh just merged on the desktop app repo, *"security is independently verifiable"* is one of the three Pro launch foundations. CodeQL on Prosponsive.ai gives that public-repo-free coverage for the website (the desktop app already has equivalent OSS-stack scanning via `gitleaks-pr` + `semgrep` + `npm-audit` in its own `security.yml`).

## What it does

- `.github/workflows/codeql.yml` (54 lines) — JS-only matrix (repo is 95% HTML / 3% JS / 2% CSS, only the JS portion is meaningfully analyzable by CodeQL).
- Uses the `security-extended` query suite (broader than default) since the attack surface is small enough that the extra rules cost little.
- Triggers: PRs targeting main, pushes to main, weekly schedule (Mondays 12:00 UTC). The schedule catches newly-disclosed CVE rules added to CodeQL upstream against unchanged code.

## Why no equivalent change on the desktop app repo

The desktop app (`Prosponsive`) is private, so GitHub-native CodeQL would require GitHub Advanced Security (paid). The team made a deliberate call to use the OSS toolchain instead — `gitleaks-pr` + `semgrep` + `npm-audit` running on every PR via `.github/workflows/security.yml`. That covers the same attack surface (secrets, SAST, dep CVEs) without the GHAS license.

## Why no equivalent change on `prosponsive-feedback`

Repo is empty (the feedback Lambda code lives in `Prosponsive` under `infra/feedback/`). Nothing to scan there until/unless the repo is populated.

## Test plan

- [ ] First run of the CodeQL workflow on this PR completes successfully (initial run on a small JS surface should be quick — under a minute typically)
- [ ] Confirm CodeQL alerts surface in the repo's Security tab after the workflow runs
- [ ] No findings expected on first run (3% JS surface, mostly trivial scripts), but if there are any, they're real signal