### PR TITLE
chore(#62): CodeQL workflow refinements (paths-ignore + concurrency)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,12 +12,31 @@ name: CodeQL
 #     code that hasn't changed but suddenly has a new known-vuln signature)
 
 on:
+  # paths-ignore: CodeQL only meaningfully analyzes JavaScript here, so PRs
+  # and pushes that only touch HTML / CSS / Markdown don't need to fire the
+  # workflow. The weekly schedule below still runs against everything so
+  # newly-disclosed CVE rules are caught even if no source has changed.
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**/*.html'
+      - '**/*.css'
+      - '**/*.md'
   push:
     branches: [main]
+    paths-ignore:
+      - '**/*.html'
+      - '**/*.css'
+      - '**/*.md'
   schedule:
     - cron: '0 12 * * 1'  # Mondays at 12:00 UTC
+
+# Cancel in-flight CodeQL runs when a new commit arrives on the same ref —
+# saves CI minutes on rapid-fire pushes to a PR branch. The scheduled run
+# uses ref `refs/heads/main` and so groups separately from PR runs.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Applies the two reviewer NITs deferred from PR #61 to `.github/workflows/codeql.yml`.

## Changes

1. **`paths-ignore` filter on `pull_request` and `push` triggers** — skips CodeQL when only `**/*.html`, `**/*.css`, or `**/*.md` change. The repo is ~95% HTML / ~3% JS / ~2% CSS, so non-JS PRs don't need to fire CodeQL. The weekly `schedule` cron still runs against everything for newly-disclosed CVE rules.
2. **`concurrency` group** — `codeql-${{ github.ref }}` with `cancel-in-progress: true` to cancel in-flight runs on rapid-fire commits to the same branch. Saves CI minutes.

## Validation

- An HTML-only PR will not trigger the CodeQL workflow (paths-ignore working).
- Pushing twice in quick succession to the same branch will cancel the first run (concurrency working).
- Weekly schedule unaffected.

Closes #62