### PR TITLE
fix(#1848): update tagline to "Personal Autonomous Agent Platform"

### DIFF
--- a/guides/basics.html
+++ b/guides/basics.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">Basics</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -254,7 +254,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -55,7 +55,7 @@
 <div class="cover">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">Comparison Guides</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -204,7 +204,7 @@
 <hr>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">vs. Zapier and Make</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -206,7 +206,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">vs. Claude Cowork</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -232,7 +232,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">vs. ChatGPT, Claude.ai, and Gemini</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -202,7 +202,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">vs. Microsoft Copilot and Google Workspace AI</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -211,7 +211,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">vs. Custom GPTs and OpenAI Assistants</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -223,7 +223,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">vs. Ollama, LM Studio, and GPT4All</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -204,7 +204,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">vs. OpenClaw</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -273,7 +273,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/email-assistant-example.html
+++ b/guides/email-assistant-example.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">Example: Email Assistant</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -358,7 +358,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/features.html
+++ b/guides/features.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">Feature Guide</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -460,7 +460,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">Feedback &amp; Philosophy</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -152,7 +152,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Lead more. Manage less.
+  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/install-guide.html
+++ b/guides/install-guide.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">Install Guide</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <div class="guide-nav">
@@ -231,7 +231,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/n8n-tool-building-guide.html
+++ b/guides/n8n-tool-building-guide.html
@@ -410,7 +410,7 @@ POST /api/ai/agent-inference
 <hr>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Lead more. Manage less.
+  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -423,7 +423,7 @@ POST /api/ai/agent-inference
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Lead more. Manage less.
+  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Personal Autonomous Agent Platform
 </div>
 
 </body>

--- a/guides/user-guide.html
+++ b/guides/user-guide.html
@@ -51,7 +51,7 @@
 <div class="cover">
   <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
   <div class="tagline">User Guide</div>
-  <div class="version">Lead more. Manage less.</div>
+  <div class="version">Personal Autonomous Agent Platform</div>
 </div>
 
 <h1>Prosponsive User Guide</h1>
@@ -94,7 +94,7 @@
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em; margin-bottom: 3em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Lead more. Manage less.
+  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
   <br><br>
   <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
 </div>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
       <h1 id="app-name" class="wordmark-heading">
         <img src="assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
       </h1>
-      <p class="tagline">Lead more. Manage less.</p>
+      <p class="tagline">Personal Autonomous Agent Platform</p>
 
       <div class="download-area">
         <a


### PR DESCRIPTION
## Summary

- Replaces all occurrences of "Lead more. Manage less." across the prosponsive.ai public docs site
- Updates `index.html` homepage tagline, cover version divs and footer wordmarks in all 16 guide HTML files
- Verification grep returns zero results

Companion to jb-brown/Prosponsive#1848.

## Test plan

- [ ] Open `index.html` — confirm tagline reads "Personal Autonomous Agent Platform"
- [ ] Spot-check a guide (e.g. `guides/basics.html`) — confirm cover version div and footer both show the new tagline
- [ ] Run `grep -ri "lead more\|manage less" . --include="*.html" --include="*.md" --include="*.json" | grep -v "\.git"` — must return zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)