### PR TITLE
Add descriptions for all sidebar tabs in basics guide

### DIFF
--- a/guides/basics.html
+++ b/guides/basics.html
@@ -241,7 +241,7 @@
 
 <h3>Set up scheduled prompts</h3>
 
-<p>Open <strong>Settings</strong> and find the <strong>Scheduled Prompts</strong> section. Set a message, pick an agent and channel, and define a schedule. The prompt fires automatically on that schedule — combined with auto-approvals, it lets Prosponsive complete recurring tasks without any input from you. See the <a href="features.html">Features guide</a> for details.</p>
+<p>Open the <strong>Schedules</strong> tab. Set a message, pick an agent and channel, and define a schedule. The prompt fires automatically on that schedule — combined with auto-approvals, it lets Prosponsive complete recurring tasks without any input from you. See the <a href="features.html">Features guide</a> for details.</p>
 
 <hr>
 

--- a/guides/basics.html
+++ b/guides/basics.html
@@ -110,6 +110,28 @@
 
 <p>The default agent is <strong>Prosponsive</strong> — your general-purpose coordinator. Prosponsive will be in all channels, and can be delegated to by all agents.</p>
 
+<h3>Schedules tab</h3>
+
+<p>Lists your scheduled prompts — recurring messages that fire automatically on a schedule you define. Each entry shows the prompt, its cadence, and its next run time. You can pause, edit, or delete schedules here.</p>
+
+<h3>Performance tab</h3>
+
+<p>Shows tool and agent usage analytics. You can see which tools are being called, how often, and by which agents. Use this to understand where your agents are spending their time and identify tools worth tuning or replacing.</p>
+
+<h3>Settings tab</h3>
+
+<p>Controls app-wide configuration:</p>
+
+<ul>
+  <li><strong>AI provider</strong> — Switch between Ollama, Bedrock, and direct providers (OpenAI, Anthropic, Google, Groq, Mistral)</li>
+  <li><strong>Inference settings</strong> — Max output length, temperature, and history depth</li>
+  <li><strong>Tool approval rules</strong> — Auto-approval conditions for trusted tools</li>
+</ul>
+
+<h3>Health tab</h3>
+
+<p>Shows the status of Prosponsive's dependencies — the AI provider, database, and workflow engine. If something isn't working, this is the first place to check. Each service shows its current state and a repair action if it's unhealthy.</p>
+
 <h3>n8n tab</h3>
 
 <p>Shows connection status and quick-access buttons:</p>


### PR DESCRIPTION
## Summary

- Added Schedules, Performance, Settings, and Health tab sections to basics.html
- All seven sidebar tabs now have equal coverage after the overview table
- Each section describes what the tab contains and when you'd use it

## Test plan

- [ ] Read through the Tour the Interface section — all seven tabs have a corresponding h3 section
- [ ] Settings section lists AI provider, inference settings, and tool approval rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)