### PR TITLE
Expand Settings tab description to cover all five sub-tabs

### DIFF
--- a/guides/basics.html
+++ b/guides/basics.html
@@ -126,8 +126,8 @@
   <li><strong>AI Configuration</strong> — Select your AI provider (Ollama, Bedrock, OpenAI, Anthropic, Google, Groq, Mistral) and model</li>
   <li><strong>Prompts</strong> — Edit the base system prompt prepended to every agent, the thread summary prompt, and the sample prompts shown when starting a new channel</li>
   <li><strong>Tool Auto Approval</strong> — Define auto-approval rules so trusted tools run without interrupting you</li>
-  <li><strong>Inference</strong> — Max output tokens, temperature, history depth, routing confidence thresholds, tool-call chain depth, and inference timeout</li>
-  <li><strong>General</strong> — Language, startup behavior, tray preferences, automatic updates, thread depth, analytics opt-out, and data retention</li>
+  <li><strong>Inference</strong> — Agent and tool caps per response, max output tokens, temperature, conversation history depth, routing and proposal confidence thresholds, tool-call chain depth, and inference timeout</li>
+  <li><strong>General</strong> — Language, startup behavior, tray preferences, automatic updates, thread nesting depth, analytics opt-out, and data retention</li>
 </ul>
 
 <h3>Health tab</h3>

--- a/guides/basics.html
+++ b/guides/basics.html
@@ -120,12 +120,14 @@
 
 <h3>Settings tab</h3>
 
-<p>Controls app-wide configuration:</p>
+<p>Controls app-wide configuration across five sub-tabs:</p>
 
 <ul>
-  <li><strong>AI provider</strong> — Switch between Ollama, Bedrock, and direct providers (OpenAI, Anthropic, Google, Groq, Mistral)</li>
-  <li><strong>Inference settings</strong> — Max output length, temperature, and history depth</li>
-  <li><strong>Tool approval rules</strong> — Auto-approval conditions for trusted tools</li>
+  <li><strong>AI Configuration</strong> — Select your AI provider (Ollama, Bedrock, OpenAI, Anthropic, Google, Groq, Mistral) and model</li>
+  <li><strong>Prompts</strong> — Edit the base system prompt prepended to every agent, the thread summary prompt, and the sample prompts shown when starting a new channel</li>
+  <li><strong>Tool Auto Approval</strong> — Define auto-approval rules so trusted tools run without interrupting you</li>
+  <li><strong>Inference</strong> — Max output tokens, temperature, history depth, routing confidence thresholds, tool-call chain depth, and inference timeout</li>
+  <li><strong>General</strong> — Language, startup behavior, tray preferences, automatic updates, thread depth, analytics opt-out, and data retention</li>
 </ul>
 
 <h3>Health tab</h3>


### PR DESCRIPTION
## Summary

The Settings tab has five sub-tabs (AI Configuration, Prompts, Tool Auto Approval, Inference, General) but the basics guide only listed three. Updated to cover all five with a one-line description of each.

## Test plan

- [ ] Settings tab section lists all five sub-tabs with accurate descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)