### PR TITLE
seo: robots.txt, sitemap.xml, Organization/Brand schema (#1981)

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,25 +18,20 @@
         "@type": "Organization",
         "name": "Prosponsive",
         "legalName": "Prosponsive, Inc.",
-        "url": "https://prosponsive.ai",
+        "url": "https://prosponsive.ai/",
         "logo": {
           "@type": "ImageObject",
           "url": "https://prosponsive.ai/assets/prosponsive-logo-icon.svg"
         },
         "description": "Personal Autonomous Agent Platform — AI-powered local assistant for knowledge workers.",
         "naics": "511210",
+        "brand": {
+          "@type": "Brand",
+          "name": "Prosponsive"
+        },
         "sameAs": [
-          "https://github.com/jb-brown/Prosponsive"
+          "https://www.linkedin.com/company/prosponsive-ai/"
         ]
-      },
-      {
-        "@type": "Brand",
-        "name": "Prosponsive",
-        "url": "https://prosponsive.ai",
-        "logo": {
-          "@type": "ImageObject",
-          "url": "https://prosponsive.ai/assets/prosponsive-logo-icon.svg"
-        }
       }
     ]
   }

--- a/index.html
+++ b/index.html
@@ -3,12 +3,44 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Prosponsive — Download</title>
-  <meta name="description" content="Download Prosponsive, the AI-powered productivity app for your desktop.">
+  <title>Prosponsive — Personal Autonomous Agent Platform</title>
+  <meta name="description" content="Prosponsive is a personal autonomous agent platform that runs AI assistants locally on your desktop. Available for macOS and Windows.">
+  <link rel="canonical" href="https://prosponsive.ai/">
   <link rel="icon" href="assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Organization",
+        "name": "Prosponsive",
+        "legalName": "Prosponsive, Inc.",
+        "url": "https://prosponsive.ai",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://prosponsive.ai/assets/prosponsive-logo-icon.svg"
+        },
+        "description": "Personal Autonomous Agent Platform — AI-powered local assistant for knowledge workers.",
+        "naics": "511210",
+        "sameAs": [
+          "https://github.com/jb-brown/Prosponsive"
+        ]
+      },
+      {
+        "@type": "Brand",
+        "name": "Prosponsive",
+        "url": "https://prosponsive.ai",
+        "logo": {
+          "@type": "ImageObject",
+          "url": "https://prosponsive.ai/assets/prosponsive-logo-icon.svg"
+        }
+      }
+    ]
+  }
+  </script>
 </head>
 <body>
   <main>

--- a/privacy/2026-04-24/index.html
+++ b/privacy/2026-04-24/index.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="/assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="/assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="/assets/icon.png?v=2026-05-04">
+  <link rel="canonical" href="https://prosponsive.ai/privacy/2026-04-24/">
   <link rel="stylesheet" href="/css/styles.css">
   <style>
     .legal-doc { display: block; max-width: 48rem; margin: 2rem auto; padding: 0 1rem 3rem; color: #1F2321; line-height: 1.6; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://prosponsive.ai/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -32,6 +32,12 @@
   </url>
 
   <url>
+    <loc>https://prosponsive.ai/guides/feedback.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://prosponsive.ai/guides/email-assistant-example.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
@@ -110,13 +116,13 @@
   </url>
 
   <url>
-    <loc>https://prosponsive.ai/privacy/</loc>
+    <loc>https://prosponsive.ai/privacy/2026-04-24/</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
 
   <url>
-    <loc>https://prosponsive.ai/terms/</loc>
+    <loc>https://prosponsive.ai/terms/2026-04-24/</loc>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <url>
+    <loc>https://prosponsive.ai/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/user-guide.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/install-guide.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/features.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/basics.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/email-assistant-example.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/n8n-tool-building-guide.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/n8n-workflow-developer-guide.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/compare/index.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/compare/vs-automation.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/compare/vs-claude-cowork.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/compare/vs-cloud-chat.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/compare/vs-copilot-workspace.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/compare/vs-custom-agents.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/compare/vs-local-models.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/guides/compare/vs-openclaw.html</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/releases/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/legal/</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/privacy/</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/terms/</loc>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+
+</urlset>

--- a/terms/2026-04-24/index.html
+++ b/terms/2026-04-24/index.html
@@ -8,6 +8,7 @@
   <link rel="icon" href="/assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="/assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="/assets/icon.png?v=2026-05-04">
+  <link rel="canonical" href="https://prosponsive.ai/terms/2026-04-24/">
   <link rel="stylesheet" href="/css/styles.css">
   <style>
     .legal-doc { display: block; max-width: 48rem; margin: 2rem auto; padding: 0 1rem 3rem; color: #1F2321; line-height: 1.6; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; }


### PR DESCRIPTION
## Summary

- Adds `robots.txt` — allows all crawlers, references sitemap
- Adds `sitemap.xml` — 21 user-facing pages with priorities
- Adds Organization schema (JSON-LD) with `naics: "511210"` (Software Publishers) — key disambiguation signal that separates Prosponsive from Prosponsive Logistics in Google's knowledge graph
- Adds Brand schema on homepage
- Updates title from "Prosponsive — Download" to "Prosponsive — Personal Autonomous Agent Platform" for brand SERP ownership
- Sharpens meta description to describe the product, not just the download action
- Adds canonical URL

Next steps (Phase 2, requires manual work):
- Submit to Google Search Console + request indexation
- Submit to Bing Webmaster Tools
- Add social profiles to `sameAs` array as they are created (Crunchbase, LinkedIn, Twitter, Product Hunt)

Closes part of #1981 in jb-brown/Prosponsive

## Test plan

- [ ] Validate schema at https://validator.schema.org — paste homepage HTML
- [ ] Validate sitemap at Google Search Console after merge
- [ ] Confirm `robots.txt` accessible at prosponsive.ai/robots.txt
- [ ] Confirm `sitemap.xml` accessible at prosponsive.ai/sitemap.xml

🤖 Generated with [Claude Code](https://claude.ai/claude-code)