### PR TITLE
Fix compare section missing from guide sequence navigation

### DIFF
--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -59,7 +59,7 @@
 </div>
 
 <div class="guide-nav">
-  <a href="../basics.html">&larr; Prosponsive Basics</a>
+  <a href="../n8n-workflow-developer-guide.html">&larr; Developer Guide</a>
   <span></span>
 </div>
 
@@ -201,7 +201,10 @@
   </tr>
 </table>
 
-<hr>
+<div class="guide-nav">
+  <a href="../n8n-workflow-developer-guide.html">&larr; Developer Guide</a>
+  <span></span>
+</div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
   <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -201,6 +201,8 @@
   </tr>
 </table>
 
+<hr>
+
 <div class="guide-nav">
   <a href="../n8n-workflow-developer-guide.html">&larr; Developer Guide</a>
   <span></span>

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -56,7 +56,7 @@
 
 <div class="guide-nav">
   <a href="feedback.html">&larr; Feedback</a>
-  <span></span>
+  <a href="compare/">How Prosponsive Compares &rarr;</a>
 </div>
 
 <h1>Building Tools with n8n</h1>
@@ -419,7 +419,7 @@ POST /api/ai/agent-inference
 
 <div class="guide-nav">
   <a href="feedback.html">&larr; Feedback</a>
-  <span></span>
+  <a href="compare/">How Prosponsive Compares &rarr;</a>
 </div>
 
 <div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">


### PR DESCRIPTION
## Summary

- Developer Guide had no \"next\" link — now points to `compare/` (How Prosponsive Compares)
- Compare page \"prev\" link was wrong (`../basics.html`) — corrected to `../n8n-workflow-developer-guide.html`
- Compare page was missing a bottom guide-nav — added to match all other guide pages

## Test plan

- [ ] Click through from Install Guide → Basics → Features → Email Assistant → Feedback → Developer Guide → How Prosponsive Compares — sequence should complete without dead ends
- [ ] Confirm the compare page bottom nav shows ← Developer Guide
- [ ] Confirm the compare page top nav shows ← Developer Guide (not ← Prosponsive Basics)

🤖 Generated with [Claude Code](https://claude.com/claude-code)