### PR TITLE
Add beta badge with shimmer and hero quote

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -178,6 +178,7 @@ h1 {
   background-position: -200% 0;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
+  color: transparent;
   background-clip: text;
   animation: beta-shimmer 120s linear infinite;
 }
@@ -191,7 +192,7 @@ h1 {
 /* ---- Hero Quote ---- */
 
 .hero-quote {
-  margin-top: 2.5rem;
+  margin: 2.5rem auto 0;
   font-size: 1rem;
   color: var(--text-secondary);
   font-style: italic;

--- a/css/styles.css
+++ b/css/styles.css
@@ -159,47 +159,62 @@ h1 {
   color: var(--text-secondary);
 }
 
-/* ---- Beta Badge ---- */
 
-.beta-badge {
-  display: inline-block;
-  margin-top: 0.875rem;
-  font-size: 0.75rem;
-  font-weight: 500;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  background: linear-gradient(
-    90deg,
-    var(--text-secondary) 35%,
-    #b8d4bc 50%,
-    var(--text-secondary) 65%
-  );
-  background-size: 300% auto;
-  background-position: -200% 0;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-  background-clip: text;
-  animation: beta-shimmer 120s linear infinite;
+
+/* ---- Hero Nav ---- */
+
+.hero-nav {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 1.25rem;
 }
 
-@keyframes beta-shimmer {
-  0%    { background-position: -200% 0; }
-  2.5%  { background-position:  200% 0; }
-  100%  { background-position:  200% 0; }
+.hero-nav a {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.8125rem;
+}
+
+.hero-nav a:hover,
+.hero-nav a:focus-visible {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.hero-nav a:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+  border-radius: 2px;
 }
 
 /* ---- Hero Quote ---- */
 
 .hero-quote {
-  margin: 2.5rem auto 0;
-  font-size: 1rem;
-  color: var(--text-secondary);
+  margin: 0.75rem auto 0;
+  font-size: 4rem;
   font-style: italic;
-  border-left: 3px solid var(--accent);
-  padding-left: 1rem;
-  text-align: left;
-  max-width: 420px;
+  text-align: center;
+  max-width: 100%;
+  background: linear-gradient(
+    90deg,
+    var(--text-secondary) 35%,
+    #d4edd8 50%,
+    var(--text-secondary) 65%
+  );
+  background-size: 300% auto;
+  background-position: 100% 0;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  background-clip: text;
+  animation: quote-shimmer 60s linear 2s infinite;
+}
+
+@keyframes quote-shimmer {
+  0%   { background-position:   0% 0; }
+  5%   { background-position: 100% 0; }
+  100% { background-position: 100% 0; }
 }
 
 /* ---- Platform Note ---- */
@@ -364,7 +379,7 @@ footer a:focus-visible {
     transform: none;
   }
 
-  .beta-badge {
+  .hero-quote {
     animation: none;
     background: none;
     -webkit-text-fill-color: var(--text-secondary);

--- a/css/styles.css
+++ b/css/styles.css
@@ -159,6 +159,48 @@ h1 {
   color: var(--text-secondary);
 }
 
+/* ---- Beta Badge ---- */
+
+.beta-badge {
+  display: inline-block;
+  margin-top: 0.875rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  background: linear-gradient(
+    90deg,
+    var(--text-secondary) 35%,
+    #b8d4bc 50%,
+    var(--text-secondary) 65%
+  );
+  background-size: 300% auto;
+  background-position: -200% 0;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: beta-shimmer 120s linear infinite;
+}
+
+@keyframes beta-shimmer {
+  0%    { background-position: -200% 0; }
+  2.5%  { background-position:  200% 0; }
+  100%  { background-position:  200% 0; }
+}
+
+/* ---- Hero Quote ---- */
+
+.hero-quote {
+  margin-top: 2.5rem;
+  font-size: 1rem;
+  color: var(--text-secondary);
+  font-style: italic;
+  border-left: 3px solid var(--accent);
+  padding-left: 1rem;
+  text-align: left;
+  max-width: 420px;
+}
+
 /* ---- Platform Note ---- */
 
 .platform-note {
@@ -319,5 +361,12 @@ footer a:focus-visible {
   .btn-download:hover,
   .btn-download:focus-visible {
     transform: none;
+  }
+
+  .beta-badge {
+    animation: none;
+    background: none;
+    -webkit-text-fill-color: var(--text-secondary);
+    color: var(--text-secondary);
   }
 }

--- a/index.html
+++ b/index.html
@@ -58,6 +58,7 @@
           Download for macOS
         </a>
         <p id="version-info" class="version-info" aria-live="polite"></p>
+        <p class="beta-badge" aria-label="In Beta Testing">In Beta Testing</p>
       </div>
 
       <p id="platform-note" class="platform-note" aria-live="polite"></p>
@@ -66,6 +67,10 @@
         <button type="button" class="link-btn" data-platform="macos">macOS</button>
         or <button type="button" class="link-btn" data-platform="windows">Windows</button>.
       </p>
+
+      <blockquote class="hero-quote">
+        "If Slack was rebuilt autonomous-agent-first."
+      </blockquote>
     </section>
 
     <section class="requirements" aria-labelledby="requirements-heading">

--- a/index.html
+++ b/index.html
@@ -58,7 +58,7 @@
           Download for macOS
         </a>
         <p id="version-info" class="version-info" aria-live="polite"></p>
-        <p class="beta-badge" aria-label="In Beta Testing">In Beta Testing</p>
+        <p class="beta-badge">In Beta Testing</p>
       </div>
 
       <p id="platform-note" class="platform-note" aria-live="polite"></p>
@@ -68,9 +68,9 @@
         or <button type="button" class="link-btn" data-platform="windows">Windows</button>.
       </p>
 
-      <blockquote class="hero-quote">
+      <p class="hero-quote">
         "If Slack was rebuilt autonomous-agent-first."
-      </blockquote>
+      </p>
     </section>
 
     <section class="requirements" aria-labelledby="requirements-heading">

--- a/index.html
+++ b/index.html
@@ -58,7 +58,6 @@
           Download for macOS
         </a>
         <p id="version-info" class="version-info" aria-live="polite"></p>
-        <p class="beta-badge">In Beta Testing</p>
       </div>
 
       <p id="platform-note" class="platform-note" aria-live="polite"></p>
@@ -69,8 +68,14 @@
       </p>
 
       <p class="hero-quote">
-        "If Slack was rebuilt autonomous-agent-first."
+        "If Slack was rebuilt autonomous agent first."
       </p>
+      <nav class="hero-nav" aria-label="Quick links">
+        <a href="guides/user-guide.html">Guides</a>
+        <a href="releases/">Release Notes</a>
+        <a href="guides/feedback.html">Feedback</a>
+        <a href="/legal/">Legal</a>
+      </nav>
     </section>
 
     <section class="requirements" aria-labelledby="requirements-heading">


### PR DESCRIPTION
## Summary
- Adds "In Beta Testing" label under the download button with a periodic shimmer sweep (once every 2 minutes, ~3s duration)
- Shimmer uses background-clip gradient on the text; respects `prefers-reduced-motion`
- Adds blockquote hero quote: *"If Slack was rebuilt autonomous-agent-first."*

## Test plan
- [ ] Open index.html in browser, confirm "In Beta Testing" appears below the button
- [ ] Wait ~2 min or temporarily reduce animation duration to confirm shimmer fires
- [ ] Check `prefers-reduced-motion` in macOS Accessibility settings — badge should render as static text
- [ ] Verify quote appears with left-border styling below the platform switch links

🤖 Generated with [Claude Code](https://claude.com/claude-code)