### PR TITLE
Implement GTM-driven website redesign (Phase 1: home + /for/ persona pages) (#79)

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -86,7 +86,6 @@ main {
 .section-subheading {
   font-size: 1.0625rem;
   color: var(--text-secondary);
-  max-width: 600px;
   margin-bottom: 0;
   line-height: 1.65;
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -386,3 +386,936 @@ footer a:focus-visible {
     color: var(--text-secondary);
   }
 }
+
+/* ================================================================
+   GTM Phase 1 — New Components
+   ================================================================ */
+
+/* ---- Secondary Button ---- */
+
+.btn-secondary {
+  display: inline-block;
+  padding: 0.75rem 1.75rem;
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--accent);
+  background-color: transparent;
+  border: 2px solid var(--accent);
+  border-radius: 8px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
+  min-width: 44px;
+  min-height: 44px;
+  line-height: 1.4;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus-visible {
+  background-color: var(--accent);
+  color: #f4f6f4;
+  transform: translateY(-1px);
+}
+
+.btn-secondary:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 3px;
+}
+
+.btn-secondary:active {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-secondary {
+    transition: none;
+  }
+  .btn-secondary:hover,
+  .btn-secondary:focus-visible {
+    transform: none;
+  }
+}
+
+/* ---- Page wrapper for full-width sections ---- */
+
+.page-wrapper {
+  width: 100%;
+  max-width: 100%;
+}
+
+.page-wrapper main {
+  max-width: 100%;
+  padding: 0;
+}
+
+/* ---- Section base ---- */
+
+.section-inner {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem;
+}
+
+/* ---- Reframe Strip ---- */
+
+.reframe-strip {
+  background-color: var(--accent);
+  color: #f4f6f4;
+  text-align: center;
+}
+
+.reframe-strip .section-inner {
+  padding: 3rem 2rem;
+}
+
+.reframe-strip p {
+  font-size: 1.25rem;
+  line-height: 1.7;
+  max-width: 720px;
+  margin: 0 auto;
+  color: #f4f6f4;
+}
+
+@media (max-width: 767px) {
+  .reframe-strip p {
+    font-size: 1.0625rem;
+  }
+}
+
+/* ---- Stat Bar ---- */
+
+.stat-bar {
+  background-color: var(--surface);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.stat-bar .section-inner {
+  padding: 3rem 1.5rem;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1rem;
+  text-align: center;
+}
+
+.stat-item {
+  padding: 1.25rem 0.75rem;
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.stat-value {
+  display: block;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+  margin-bottom: 0.375rem;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.4;
+}
+
+@media (max-width: 767px) {
+  .stat-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+  }
+  .stat-grid .stat-item:last-child {
+    grid-column: 1 / -1;
+  }
+  .stat-value {
+    font-size: 1.5rem;
+  }
+}
+
+/* ---- Pillar Sections ---- */
+
+.pillar-section {
+  padding: 0;
+}
+
+.pillar-section:nth-child(even) {
+  background-color: var(--surface);
+}
+
+.pillar-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.pillar-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  background-color: var(--accent);
+  color: #f4f6f4;
+  border-radius: 50%;
+  font-size: 0.875rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.pillar-section h2 {
+  font-size: 1.875rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  margin-bottom: 0;
+}
+
+.pillar-body {
+  max-width: 680px;
+}
+
+.pillar-body p {
+  font-size: 1.0625rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  margin-bottom: 1.25rem;
+}
+
+.pillar-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+  margin: 1.5rem 0;
+}
+
+.pillar-metric {
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.5rem 0.875rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+.pillar-metric strong {
+  color: var(--accent);
+  font-weight: 700;
+}
+
+.pillar-cta {
+  margin-top: 1.5rem;
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+@media (max-width: 767px) {
+  .pillar-section h2 {
+    font-size: 1.5rem;
+  }
+  .pillar-cta {
+    flex-direction: column;
+  }
+  .pillar-cta .btn-download,
+  .pillar-cta .btn-secondary {
+    text-align: center;
+  }
+}
+
+/* ---- How It Works Mini ---- */
+
+.how-it-works-mini {
+  background-color: var(--surface);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.hiw-steps {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 1rem;
+  margin: 2rem 0;
+  text-align: center;
+  position: relative;
+}
+
+.hiw-step {
+  padding: 1.5rem 1rem;
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  position: relative;
+}
+
+.hiw-step-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background-color: var(--accent);
+  color: #f4f6f4;
+  border-radius: 50%;
+  font-size: 0.875rem;
+  font-weight: 700;
+  margin: 0 auto 0.75rem;
+}
+
+.hiw-step h3 {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.hiw-step p {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+}
+
+.hiw-link {
+  text-align: center;
+  margin-top: 2rem;
+}
+
+@media (max-width: 767px) {
+  .hiw-steps {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ---- Persona Selector ---- */
+
+.persona-selector {
+  padding: 0;
+}
+
+.persona-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.persona-card {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-left: 4px solid var(--accent);
+  border-radius: 0 12px 12px 0;
+  padding: 1.5rem;
+  text-decoration: none;
+  display: block;
+  transition: border-color 0.15s ease, transform 0.1s ease;
+}
+
+.persona-card:hover,
+.persona-card:focus-visible {
+  border-left-color: var(--accent-hover);
+  transform: translateY(-2px);
+}
+
+.persona-card:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 3px;
+}
+
+.persona-card-tier {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--accent);
+  margin-bottom: 0.375rem;
+}
+
+.persona-card h3 {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.persona-card p {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0;
+}
+
+.persona-card-arrow {
+  display: block;
+  margin-top: 1rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+@media (max-width: 767px) {
+  .persona-grid {
+    grid-template-columns: 1fr;
+  }
+  .persona-card:hover,
+  .persona-card:focus-visible {
+    transform: none;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .persona-card {
+    transition: none;
+  }
+  .persona-card:hover,
+  .persona-card:focus-visible {
+    transform: none;
+  }
+}
+
+/* ---- Social Proof ---- */
+
+.social-proof {
+  background-color: var(--surface);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.quote-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin: 2rem 0;
+}
+
+.quote-block {
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 4px solid #4f6f5c;
+  border-radius: 0 12px 12px 0;
+  padding: 1.5rem 1.75rem;
+}
+
+.quote-block blockquote {
+  margin: 0 0 1rem;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--text-primary);
+  font-style: italic;
+}
+
+.quote-block cite {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  font-style: normal;
+}
+
+.outcome-table-wrap {
+  margin-top: 2.5rem;
+  overflow-x: auto;
+}
+
+.outcome-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+}
+
+.outcome-table thead th {
+  background-color: var(--accent);
+  color: #f4f6f4;
+  padding: 0.625rem 1rem;
+  text-align: left;
+  font-weight: 600;
+}
+
+.outcome-table tbody tr:nth-child(even) td {
+  background-color: var(--surface);
+}
+
+.outcome-table tbody td {
+  padding: 0.625rem 1rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+  vertical-align: top;
+}
+
+.outcome-table tbody td:first-child {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+@media (max-width: 767px) {
+  .quote-grid {
+    grid-template-columns: 1fr;
+  }
+  .outcome-table-wrap {
+    font-size: 0.875rem;
+  }
+}
+
+/* ---- Competitive Teaser ---- */
+
+.competitive-teaser {
+  text-align: center;
+}
+
+.competitive-teaser h2 {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.75rem;
+}
+
+.competitive-teaser p {
+  font-size: 1.0625rem;
+  color: var(--text-secondary);
+  max-width: 560px;
+  margin: 0 auto 1.5rem;
+}
+
+/* ---- Final CTA Band ---- */
+
+.cta-band {
+  background-color: var(--accent);
+  color: #f4f6f4;
+  text-align: center;
+}
+
+.cta-band .section-inner {
+  padding: 4rem 1.5rem;
+}
+
+.cta-band h2 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #f4f6f4;
+  margin-bottom: 0.75rem;
+}
+
+.cta-band p {
+  font-size: 1.125rem;
+  color: rgba(244, 246, 244, 0.85);
+  max-width: 560px;
+  margin: 0 auto 2rem;
+}
+
+.cta-band .btn-download {
+  background-color: #f4f6f4;
+  color: var(--accent);
+}
+
+.cta-band .btn-download:hover,
+.cta-band .btn-download:focus-visible {
+  background-color: #e6eae7;
+}
+
+.cta-band .requirements {
+  background-color: rgba(244, 246, 244, 0.1);
+  border-color: rgba(244, 246, 244, 0.25);
+  margin-top: 2rem;
+  text-align: left;
+  max-width: 500px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.cta-band .requirements h2 {
+  font-size: 1rem;
+  color: rgba(244, 246, 244, 0.75);
+}
+
+.cta-band .requirements li {
+  color: rgba(244, 246, 244, 0.7);
+  border-bottom-color: rgba(244, 246, 244, 0.15);
+}
+
+.cta-band .requirements li strong {
+  color: rgba(244, 246, 244, 0.9);
+}
+
+@media (max-width: 767px) {
+  .cta-band h2 {
+    font-size: 1.5rem;
+  }
+  .cta-band .btn-download {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+/* ---- Site-wide Header Nav ---- */
+
+.site-header {
+  background-color: var(--bg);
+  border-bottom: 1px solid var(--border);
+  padding: 0 1.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 100;
+}
+
+.site-header-inner {
+  max-width: 900px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 60px;
+}
+
+.site-header-logo {
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.site-header-logo img {
+  height: 28px;
+  width: auto;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-nav a {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.site-nav a:hover,
+.site-nav a:focus-visible {
+  color: var(--accent);
+}
+
+.site-nav a:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+.site-nav .nav-cta {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+@media (max-width: 767px) {
+  .site-nav {
+    gap: 1rem;
+  }
+  .site-nav a {
+    font-size: 0.8125rem;
+  }
+}
+
+/* ---- Persona Page Layout ---- */
+
+.persona-hero {
+  background-color: var(--accent);
+  color: #f4f6f4;
+}
+
+.persona-hero .section-inner {
+  padding: 4rem 1.5rem 3rem;
+}
+
+.persona-hero-label {
+  display: inline-block;
+  background-color: rgba(244, 246, 244, 0.15);
+  color: rgba(244, 246, 244, 0.9);
+  font-size: 0.8125rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.25rem 0.75rem;
+  border-radius: 4px;
+  margin-bottom: 1.25rem;
+}
+
+.persona-hero h1 {
+  font-size: 2.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #f4f6f4;
+  margin-bottom: 1rem;
+  max-width: 680px;
+}
+
+.persona-hero-message {
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: rgba(244, 246, 244, 0.85);
+  max-width: 640px;
+  margin-bottom: 2rem;
+}
+
+.persona-hero-cta {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.persona-hero .btn-download {
+  background-color: #f4f6f4;
+  color: var(--accent);
+}
+
+.persona-hero .btn-download:hover,
+.persona-hero .btn-download:focus-visible {
+  background-color: #e6eae7;
+}
+
+.persona-hero .btn-secondary {
+  border-color: rgba(244, 246, 244, 0.6);
+  color: rgba(244, 246, 244, 0.9);
+}
+
+.persona-hero .btn-secondary:hover,
+.persona-hero .btn-secondary:focus-visible {
+  background-color: rgba(244, 246, 244, 0.15);
+  color: #f4f6f4;
+}
+
+@media (max-width: 767px) {
+  .persona-hero h1 {
+    font-size: 1.875rem;
+  }
+  .persona-hero-cta {
+    flex-direction: column;
+  }
+  .persona-hero .btn-download,
+  .persona-hero .btn-secondary {
+    text-align: center;
+  }
+}
+
+/* ---- Value Props List ---- */
+
+.value-props {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.value-prop-item {
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.value-prop-rank {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  background-color: var(--accent);
+  color: #f4f6f4;
+  border-radius: 50%;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+}
+
+.value-prop-content h3 {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.375rem;
+}
+
+.value-prop-content p {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ---- Section Headings ---- */
+
+.section-heading {
+  font-size: 1.75rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.section-subheading {
+  font-size: 1.0625rem;
+  color: var(--text-secondary);
+  max-width: 600px;
+  margin-bottom: 0;
+}
+
+/* ---- Capability Table ---- */
+
+.capability-table-wrap {
+  overflow-x: auto;
+  margin-top: 1.5rem;
+}
+
+.capability-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+}
+
+.capability-table thead th {
+  background-color: var(--accent);
+  color: #f4f6f4;
+  padding: 0.625rem 1rem;
+  text-align: left;
+  font-weight: 600;
+}
+
+.capability-table tbody tr:nth-child(even) td {
+  background-color: var(--surface);
+}
+
+.capability-table tbody td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+  vertical-align: top;
+  line-height: 1.5;
+}
+
+.capability-table tbody td:first-child {
+  color: var(--text-primary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.capability-table .metric {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+/* ---- Breadcrumb ---- */
+
+.breadcrumb {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  padding: 0.875rem 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 0;
+}
+
+.breadcrumb a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb span {
+  margin: 0 0.375rem;
+}
+
+/* ---- How It Works Full Page ---- */
+
+.hiw-narrative {
+  max-width: 740px;
+}
+
+.hiw-narrative p {
+  font-size: 1.0625rem;
+  line-height: 1.75;
+  color: var(--text-secondary);
+  margin-bottom: 1.25rem;
+}
+
+.hiw-narrative p + p {
+  margin-top: 0;
+}
+
+.hiw-narrative strong {
+  color: var(--text-primary);
+}
+
+.hiw-full-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  margin: 2.5rem 0;
+}
+
+.hiw-full-step {
+  display: flex;
+  gap: 1.5rem;
+  align-items: flex-start;
+}
+
+.hiw-full-step-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  background-color: var(--accent);
+  color: #f4f6f4;
+  border-radius: 50%;
+  font-size: 1.125rem;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.hiw-full-step-content h3 {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.hiw-full-step-content p {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  line-height: 1.65;
+  margin: 0;
+}
+
+/* ---- Footer nav extensions ---- */
+
+.footer-nav-extended {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+}
+
+.footer-section-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+@media (max-width: 767px) {
+  .hiw-full-step {
+    flex-direction: column;
+  }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -931,7 +931,7 @@ footer a:focus-visible {
 }
 
 .cta-band .requirements li {
-  color: rgba(244, 246, 244, 0.7);
+  color: rgba(244, 246, 244, 0.8);
   border-bottom-color: rgba(244, 246, 244, 0.15);
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -258,7 +258,7 @@ main {
 
 .hero {
   text-align: center;
-  padding: 6rem 1.5rem 5rem;
+  padding: 4rem 1.5rem 1rem;
   background: radial-gradient(ellipse 80% 60% at 50% 0%, rgba(47, 79, 62, 0.07) 0%, transparent 70%);
 }
 
@@ -489,13 +489,13 @@ h1 {
 
 .stat-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1rem;
+  grid-template-columns: repeat(6, 1fr);
+  gap: 0.75rem;
   text-align: center;
 }
 
 .stat-item {
-  padding: 1.5rem 0.75rem;
+  padding: 1.25rem 0.625rem;
   background-color: var(--bg);
   border: 1px solid var(--border);
   border-radius: 12px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,5 +1,5 @@
 /* ================================================================
-   Prosponsive Download Page — Dark Theme
+   Prosponsive — Marketing Site Styles
    ================================================================ */
 
 :root {
@@ -41,916 +41,59 @@ body {
   flex-direction: column;
 }
 
-main {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 4rem 1.5rem 2rem;
-  max-width: 800px;
-  margin: 0 auto;
-  width: 100%;
-}
-
-/* ---- Hero ---- */
-
-.hero {
-  text-align: center;
-  padding: 2rem 0 3rem;
-}
-
-.app-icon {
-  display: block;
-  margin: 0 auto 1.5rem;
-  border-radius: 22%;
-}
-
-/* Wordmark replaces logo + brand-name pair in hero. The image already
-   contains the green-stem P glyph and the "rosponsive" wordmark, so the
-   surrounding <h1> is unstyled — it exists for document outline and
-   accessibility only. */
-.wordmark-heading {
-  margin: 0 0 0.5rem;
-  line-height: 0;
-}
-
-/* .cover-wordmark — large centered wordmark used on the home page hero
-   and the cover block of every guide page. Same class name everywhere
-   so home + guides share styling. */
-.cover-wordmark {
-  width: 360px;
-  max-width: 90%;
-  height: auto;
-  margin: 0 auto;
-  display: block;
-}
-
-/* .footer-wordmark — small inline wordmark used in guide footers next to
-   the tagline. */
-.footer-wordmark {
-  height: 28px;
-  width: auto;
-  vertical-align: middle;
-  margin-right: 0.4em;
-}
-
-h1 {
-  font-size: 3rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  margin-bottom: 0.5rem;
-}
-
-.tagline {
-  font-size: 1.25rem;
-  color: var(--text-secondary);
-  margin-bottom: 2.5rem;
-}
-
-/* ---- Download Button ---- */
-
-.download-area {
-  margin-bottom: 1.5rem;
-}
-
-.btn-download {
-  display: inline-block;
-  padding: 0.875rem 2.5rem;
-  font-size: 1.125rem;
-  font-weight: 600;
-  color: #f4f6f4;
-  background-color: var(--accent);
-  border: none;
-  border-radius: 8px;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 0.15s ease, transform 0.1s ease;
-  min-width: 44px;
-  min-height: 44px;
-}
-
-.btn-download:hover,
-.btn-download:focus-visible {
-  background-color: var(--accent-hover);
-  transform: translateY(-1px);
-}
-
-.btn-download:focus-visible {
-  outline: 2px solid var(--accent-hover);
-  outline-offset: 3px;
-}
-
-.btn-download:active {
-  transform: translateY(0);
-}
-
-.btn-download[aria-disabled="true"] {
-  background-color: var(--border);
-  color: var(--text-secondary);
-  cursor: default;
-  pointer-events: none;
-}
-
-/* ---- Version Info ---- */
-
-.version-info {
-  margin-top: 0.75rem;
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-}
-
-
-
-/* ---- Hero Nav ---- */
-
-.hero-nav {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-  margin-top: 1.25rem;
-}
-
-.hero-nav a {
-  color: var(--accent);
-  text-decoration: none;
-  font-size: 0.8125rem;
-}
-
-.hero-nav a:hover,
-.hero-nav a:focus-visible {
-  color: var(--accent-hover);
-  text-decoration: underline;
-}
-
-.hero-nav a:focus-visible {
-  outline: 2px solid var(--accent-hover);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
-/* ---- Hero Quote ---- */
-
-.hero-quote {
-  margin: 0.75rem auto 0;
-  font-size: 4rem;
-  font-style: italic;
-  text-align: center;
-  max-width: 100%;
-  background: linear-gradient(
-    90deg,
-    var(--text-secondary) 35%,
-    #d4edd8 50%,
-    var(--text-secondary) 65%
-  );
-  background-size: 300% auto;
-  background-position: 100% 0;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-  background-clip: text;
-  animation: quote-shimmer 60s linear 2s infinite;
-}
-
-@keyframes quote-shimmer {
-  0%   { background-position:   0% 0; }
-  5%   { background-position: 100% 0; }
-  100% { background-position: 100% 0; }
-}
-
-/* ---- Platform Note ---- */
-
-.platform-note {
-  font-size: 0.9375rem;
-  color: var(--text-secondary);
-  margin-bottom: 0.5rem;
-}
-
-.platform-switch {
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
-}
-
-.link-btn {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  font-size: inherit;
-  font-family: inherit;
-  text-decoration: underline;
-  padding: 0;
-  min-width: 44px;
-  min-height: 44px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.link-btn:hover,
-.link-btn:focus-visible {
-  color: var(--accent-hover);
-}
-
-.link-btn:focus-visible {
-  outline: 2px solid var(--accent-hover);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
-/* ---- Requirements ---- */
-
-.requirements {
-  width: 100%;
-  background-color: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 2rem;
-  margin-top: 1rem;
-}
-
-.requirements h2 {
-  font-size: 1.25rem;
-  font-weight: 600;
-  margin-bottom: 1rem;
-}
-
-.requirements ul {
-  list-style: none;
-  padding: 0;
-}
-
-.requirements li {
-  padding: 0.375rem 0;
-  font-size: 0.9375rem;
-  color: var(--text-secondary);
-  border-bottom: 1px solid var(--border);
-}
-
-.requirements li:last-child {
-  border-bottom: none;
-}
-
-.requirements li strong {
-  color: var(--text-primary);
-}
-
-.requirements li em {
-  color: var(--accent);
-  font-style: normal;
-}
-
-/* ---- Footer ---- */
-
-footer {
-  text-align: center;
-  padding: 2rem 1.5rem;
-  border-top: 1px solid var(--border);
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
-}
-
-footer p {
-  margin-bottom: 0.75rem;
-}
-
-footer nav {
-  display: flex;
-  justify-content: center;
-  gap: 1.5rem;
-}
-
-footer a {
-  color: var(--accent);
-  text-decoration: none;
-}
-
-footer a:hover,
-footer a:focus-visible {
-  color: var(--accent-hover);
-  text-decoration: underline;
-}
-
-footer a:focus-visible {
-  outline: 2px solid var(--accent-hover);
-  outline-offset: 2px;
-  border-radius: 2px;
-}
-
-/* ---- Responsive ---- */
-
-@media (max-width: 767px) {
-  main {
-    padding: 2rem 1rem 1.5rem;
-  }
-
-  h1 {
-    font-size: 2.25rem;
-  }
-
-  .tagline {
-    font-size: 1.0625rem;
-  }
-
-  .btn-download {
-    display: block;
-    width: 100%;
-    text-align: center;
-  }
-
-  .requirements {
-    padding: 1.5rem;
-  }
-
-  footer nav {
-    flex-direction: column;
-    gap: 0.75rem;
-  }
-}
-
-/* ---- Reduced Motion ---- */
-
-@media (prefers-reduced-motion: reduce) {
-  .btn-download {
-    transition: none;
-  }
-
-  .btn-download:hover,
-  .btn-download:focus-visible {
-    transform: none;
-  }
-
-  .hero-quote {
-    animation: none;
-    background: none;
-    -webkit-text-fill-color: var(--text-secondary);
-    color: var(--text-secondary);
-  }
-}
-
-/* ================================================================
-   GTM Phase 1 — New Components
-   ================================================================ */
-
-/* ---- Secondary Button ---- */
-
-.btn-secondary {
-  display: inline-block;
-  padding: 0.75rem 1.75rem;
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--accent);
-  background-color: transparent;
-  border: 2px solid var(--accent);
-  border-radius: 8px;
-  text-decoration: none;
-  cursor: pointer;
-  transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
-  min-width: 44px;
-  min-height: 44px;
-  line-height: 1.4;
-}
-
-.btn-secondary:hover,
-.btn-secondary:focus-visible {
-  background-color: var(--accent);
-  color: #f4f6f4;
-  transform: translateY(-1px);
-}
-
-.btn-secondary:focus-visible {
-  outline: 2px solid var(--accent-hover);
-  outline-offset: 3px;
-}
-
-.btn-secondary:active {
-  transform: translateY(0);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .btn-secondary {
-    transition: none;
-  }
-  .btn-secondary:hover,
-  .btn-secondary:focus-visible {
-    transform: none;
-  }
-}
-
-/* ---- Page wrapper for full-width sections ---- */
+/* ---- Page wrapper ---- */
 
 .page-wrapper {
   width: 100%;
   max-width: 100%;
 }
 
-.page-wrapper main {
-  max-width: 100%;
-  padding: 0;
+/* main must be full-width — sections control their own inner width */
+main {
+  flex: 1;
+  width: 100%;
 }
 
-/* ---- Section base ---- */
+/* ---- Utility ---- */
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+}
+
+/* ---- Section inner wrapper ---- */
 
 .section-inner {
-  max-width: 900px;
+  max-width: 1100px;
   margin: 0 auto;
-  padding: 4rem 1.5rem;
+  padding: 5rem 1.5rem;
 }
 
-/* ---- Reframe Strip ---- */
+/* ---- Section Headings ---- */
 
-.reframe-strip {
-  background-color: var(--accent);
-  color: #f4f6f4;
-  text-align: center;
-}
-
-.reframe-strip .section-inner {
-  padding: 3rem 2rem;
-}
-
-.reframe-strip p {
-  font-size: 1.25rem;
-  line-height: 1.7;
-  max-width: 720px;
-  margin: 0 auto;
-  color: #f4f6f4;
-}
-
-@media (max-width: 767px) {
-  .reframe-strip p {
-    font-size: 1.0625rem;
-  }
-}
-
-/* ---- Stat Bar ---- */
-
-.stat-bar {
-  background-color: var(--surface);
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.stat-bar .section-inner {
-  padding: 3rem 1.5rem;
-}
-
-.stat-grid {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1rem;
-  text-align: center;
-}
-
-.stat-item {
-  padding: 1.25rem 0.75rem;
-  background-color: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-}
-
-.stat-value {
-  display: block;
-  font-size: 1.75rem;
-  font-weight: 700;
-  color: var(--accent);
-  letter-spacing: -0.02em;
-  margin-bottom: 0.375rem;
-}
-
-.stat-label {
-  display: block;
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
-  line-height: 1.4;
-}
-
-@media (max-width: 767px) {
-  .stat-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 0.75rem;
-  }
-  .stat-grid .stat-item:last-child {
-    grid-column: 1 / -1;
-  }
-  .stat-value {
-    font-size: 1.5rem;
-  }
-}
-
-/* ---- Pillar Sections ---- */
-
-.pillar-section {
-  padding: 0;
-}
-
-.pillar-section:nth-child(even) {
-  background-color: var(--surface);
-}
-
-.pillar-header {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
-}
-
-.pillar-number {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem;
-  height: 2.5rem;
-  background-color: var(--accent);
-  color: #f4f6f4;
-  border-radius: 50%;
-  font-size: 0.875rem;
-  font-weight: 700;
-  flex-shrink: 0;
-}
-
-.pillar-section h2 {
-  font-size: 1.875rem;
+.section-heading {
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
   font-weight: 700;
   letter-spacing: -0.02em;
   color: var(--text-primary);
+  margin-bottom: 0.75rem;
+}
+
+.section-subheading {
+  font-size: 1.0625rem;
+  color: var(--text-secondary);
+  max-width: 600px;
   margin-bottom: 0;
+  line-height: 1.65;
 }
 
-.pillar-body {
-  max-width: 680px;
-}
-
-.pillar-body p {
-  font-size: 1.0625rem;
-  color: var(--text-secondary);
-  line-height: 1.7;
-  margin-bottom: 1.25rem;
-}
-
-.pillar-metrics {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.625rem;
-  margin: 1.5rem 0;
-}
-
-.pillar-metric {
-  background-color: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 0.5rem 0.875rem;
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-}
-
-.pillar-metric strong {
-  color: var(--accent);
-  font-weight: 700;
-}
-
-.pillar-cta {
-  margin-top: 1.5rem;
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-@media (max-width: 767px) {
-  .pillar-section h2 {
-    font-size: 1.5rem;
-  }
-  .pillar-cta {
-    flex-direction: column;
-  }
-  .pillar-cta .btn-download,
-  .pillar-cta .btn-secondary {
-    text-align: center;
-  }
-}
-
-/* ---- How It Works Mini ---- */
-
-.how-it-works-mini {
-  background-color: var(--surface);
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.hiw-steps {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 1rem;
-  margin: 2rem 0;
-  text-align: center;
-  position: relative;
-}
-
-.hiw-step {
-  padding: 1.5rem 1rem;
-  background-color: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  position: relative;
-}
-
-.hiw-step-number {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2rem;
-  height: 2rem;
-  background-color: var(--accent);
-  color: #f4f6f4;
-  border-radius: 50%;
-  font-size: 0.875rem;
-  font-weight: 700;
-  margin: 0 auto 0.75rem;
-}
-
-.hiw-step h3 {
-  font-size: 0.9375rem;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin-bottom: 0.5rem;
-}
-
-.hiw-step p {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.5;
-}
-
-.hiw-link {
-  text-align: center;
-  margin-top: 2rem;
-}
-
-@media (max-width: 767px) {
-  .hiw-steps {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-/* ---- Persona Selector ---- */
-
-.persona-selector {
-  padding: 0;
-}
-
-.persona-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
-  margin-top: 2rem;
-}
-
-.persona-card {
-  background-color: var(--surface);
-  border: 1px solid var(--border);
-  border-left: 4px solid var(--accent);
-  border-radius: 0 12px 12px 0;
-  padding: 1.5rem;
-  text-decoration: none;
-  display: block;
-  transition: border-color 0.15s ease, transform 0.1s ease;
-}
-
-.persona-card:hover,
-.persona-card:focus-visible {
-  border-left-color: var(--accent-hover);
-  transform: translateY(-2px);
-}
-
-.persona-card:focus-visible {
-  outline: 2px solid var(--accent-hover);
-  outline-offset: 3px;
-}
-
-.persona-card-tier {
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-  color: var(--accent);
-  margin-bottom: 0.375rem;
-}
-
-.persona-card h3 {
-  font-size: 1.0625rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-bottom: 0.5rem;
-}
-
-.persona-card p {
-  font-size: 0.875rem;
-  color: var(--text-secondary);
-  line-height: 1.5;
-  margin: 0;
-}
-
-.persona-card-arrow {
-  display: block;
-  margin-top: 1rem;
-  font-size: 0.8125rem;
-  font-weight: 600;
-  color: var(--accent);
-}
-
-@media (max-width: 767px) {
-  .persona-grid {
-    grid-template-columns: 1fr;
-  }
-  .persona-card:hover,
-  .persona-card:focus-visible {
-    transform: none;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .persona-card {
-    transition: none;
-  }
-  .persona-card:hover,
-  .persona-card:focus-visible {
-    transform: none;
-  }
-}
-
-/* ---- Social Proof ---- */
-
-.social-proof {
-  background-color: var(--surface);
-  border-top: 1px solid var(--border);
-  border-bottom: 1px solid var(--border);
-}
-
-.quote-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-  margin: 2rem 0;
-}
-
-.quote-block {
-  background-color: var(--bg);
-  border: 1px solid var(--border);
-  border-left: 4px solid #4f6f5c;
-  border-radius: 0 12px 12px 0;
-  padding: 1.5rem 1.75rem;
-}
-
-.quote-block blockquote {
-  margin: 0 0 1rem;
-  font-size: 0.9375rem;
-  line-height: 1.7;
-  color: var(--text-primary);
-  font-style: italic;
-}
-
-.quote-block cite {
-  font-size: 0.8125rem;
-  color: var(--text-secondary);
-  font-style: normal;
-}
-
-.outcome-table-wrap {
-  margin-top: 2.5rem;
-  overflow-x: auto;
-}
-
-.outcome-table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: 0.9375rem;
-}
-
-.outcome-table thead th {
-  background-color: var(--accent);
-  color: #f4f6f4;
-  padding: 0.625rem 1rem;
-  text-align: left;
-  font-weight: 600;
-}
-
-.outcome-table tbody tr:nth-child(even) td {
-  background-color: var(--surface);
-}
-
-.outcome-table tbody td {
-  padding: 0.625rem 1rem;
-  border-bottom: 1px solid var(--border);
-  color: var(--text-secondary);
-  vertical-align: top;
-}
-
-.outcome-table tbody td:first-child {
-  color: var(--text-primary);
-  font-weight: 500;
-}
-
-@media (max-width: 767px) {
-  .quote-grid {
-    grid-template-columns: 1fr;
-  }
-  .outcome-table-wrap {
-    font-size: 0.875rem;
-  }
-}
-
-/* ---- Competitive Teaser ---- */
-
-.competitive-teaser {
-  text-align: center;
-}
-
-.competitive-teaser h2 {
-  font-size: 1.5rem;
-  font-weight: 700;
-  color: var(--text-primary);
-  margin-bottom: 0.75rem;
-}
-
-.competitive-teaser p {
-  font-size: 1.0625rem;
-  color: var(--text-secondary);
-  max-width: 560px;
-  margin: 0 auto 1.5rem;
-}
-
-/* ---- Final CTA Band ---- */
-
-.cta-band {
-  background-color: var(--accent);
-  color: #f4f6f4;
-  text-align: center;
-}
-
-.cta-band .section-inner {
-  padding: 4rem 1.5rem;
-}
-
-.cta-band h2 {
-  font-size: 2rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: #f4f6f4;
-  margin-bottom: 0.75rem;
-}
-
-.cta-band p {
-  font-size: 1.125rem;
-  color: rgba(244, 246, 244, 0.85);
-  max-width: 560px;
-  margin: 0 auto 2rem;
-}
-
-.cta-band .btn-download {
-  background-color: #f4f6f4;
-  color: var(--accent);
-}
-
-.cta-band .btn-download:hover,
-.cta-band .btn-download:focus-visible {
-  background-color: #e6eae7;
-}
-
-.cta-band .requirements {
-  background-color: rgba(244, 246, 244, 0.1);
-  border-color: rgba(244, 246, 244, 0.25);
-  margin-top: 2rem;
-  text-align: left;
-  max-width: 500px;
-  margin-left: auto;
-  margin-right: auto;
-}
-
-.cta-band .requirements h2 {
-  font-size: 1rem;
-  color: rgba(244, 246, 244, 0.75);
-}
-
-.cta-band .requirements li {
-  color: rgba(244, 246, 244, 0.8);
-  border-bottom-color: rgba(244, 246, 244, 0.15);
-}
-
-.cta-band .requirements li strong {
-  color: rgba(244, 246, 244, 0.9);
-}
-
-@media (max-width: 767px) {
-  .cta-band h2 {
-    font-size: 1.5rem;
-  }
-  .cta-band .btn-download {
-    display: block;
-    width: 100%;
-    text-align: center;
-  }
-}
-
-/* ---- Site-wide Header Nav ---- */
+/* ================================================================
+   Site Header
+   ================================================================ */
 
 .site-header {
   background-color: var(--bg);
@@ -962,7 +105,7 @@ footer a:focus-visible {
 }
 
 .site-header-inner {
-  max-width: 900px;
+  max-width: 1100px;
   margin: 0 auto;
   display: flex;
   align-items: center;
@@ -1019,7 +162,864 @@ footer a:focus-visible {
   }
 }
 
-/* ---- Persona Page Layout ---- */
+/* ================================================================
+   Buttons
+   ================================================================ */
+
+/* Primary download button */
+.btn-download {
+  display: inline-block;
+  padding: 0.875rem 2.5rem;
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #f4f6f4;
+  background-color: var(--accent);
+  border: none;
+  border-radius: 8px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, transform 0.1s ease;
+  min-width: 44px;
+  min-height: 44px;
+}
+
+.btn-download:hover,
+.btn-download:focus-visible {
+  background-color: var(--accent-hover);
+  transform: translateY(-1px);
+}
+
+.btn-download:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 3px;
+}
+
+.btn-download:active {
+  transform: translateY(0);
+}
+
+.btn-download[aria-disabled="true"] {
+  background-color: var(--border);
+  color: var(--text-secondary);
+  cursor: default;
+  pointer-events: none;
+}
+
+/* Secondary outline button */
+.btn-secondary {
+  display: inline-block;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--accent);
+  background: transparent;
+  border: 2px solid var(--accent);
+  border-radius: 8px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: background-color 0.15s ease, color 0.15s ease, transform 0.1s ease;
+  min-width: 44px;
+  min-height: 44px;
+  line-height: 1.4;
+}
+
+.btn-secondary:hover,
+.btn-secondary:focus-visible {
+  background-color: var(--accent);
+  color: #f4f6f4;
+  transform: translateY(-1px);
+}
+
+.btn-secondary:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 3px;
+}
+
+.btn-secondary:active {
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-download,
+  .btn-secondary {
+    transition: none;
+  }
+  .btn-download:hover,
+  .btn-download:focus-visible,
+  .btn-secondary:hover,
+  .btn-secondary:focus-visible {
+    transform: none;
+  }
+}
+
+/* ================================================================
+   Hero
+   ================================================================ */
+
+.hero {
+  text-align: center;
+  padding: 6rem 1.5rem 5rem;
+  background: radial-gradient(ellipse 80% 60% at 50% 0%, rgba(47, 79, 62, 0.07) 0%, transparent 70%);
+}
+
+/* Wordmark heading — exists for document outline/a11y; visual is the img */
+.wordmark-heading {
+  margin: 0 0 0.5rem;
+  line-height: 0;
+}
+
+/* Large centered wordmark — shared with guide page covers */
+.cover-wordmark {
+  width: 360px;
+  max-width: 90%;
+  height: auto;
+  margin: 0 auto;
+  display: block;
+}
+
+/* Small wordmark used in guide footers */
+.footer-wordmark {
+  height: 28px;
+  width: auto;
+  vertical-align: middle;
+  margin-right: 0.4em;
+}
+
+h1 {
+  font-size: 3rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+}
+
+.tagline {
+  font-size: clamp(1.25rem, 3vw, 1.625rem);
+  font-weight: 500;
+  color: var(--text-secondary);
+  margin-bottom: 2.75rem;
+  letter-spacing: -0.01em;
+}
+
+/* ---- Download area ---- */
+
+.download-area {
+  margin-bottom: 1.5rem;
+}
+
+.version-info {
+  margin-top: 0.75rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+/* ---- Platform note ---- */
+
+.platform-note {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  margin-bottom: 0.5rem;
+}
+
+.platform-switch {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.link-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+  text-decoration: underline;
+  padding: 0;
+  min-width: 44px;
+  min-height: 44px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.link-btn:hover,
+.link-btn:focus-visible {
+  color: var(--accent-hover);
+}
+
+.link-btn:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+/* ---- Hero quote — pull-quote style ---- */
+
+.hero-quote {
+  margin: 1.75rem auto 0;
+  font-size: clamp(1.125rem, 2.5vw, 1.5rem);
+  font-style: italic;
+  text-align: center;
+  max-width: 640px;
+  color: var(--text-secondary);
+  padding-left: 1.25rem;
+  border-left: 3px solid var(--accent);
+  text-align: left;
+}
+
+/* ---- Hero nav quick links ---- */
+
+.hero-nav {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  margin-top: 1.75rem;
+}
+
+.hero-nav a {
+  color: var(--accent);
+  text-decoration: none;
+  font-size: 0.8125rem;
+}
+
+.hero-nav a:hover,
+.hero-nav a:focus-visible {
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+
+.hero-nav a:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+@media (max-width: 767px) {
+  .hero {
+    padding: 4rem 1.25rem 3.5rem;
+  }
+
+  h1 {
+    font-size: 2.25rem;
+  }
+
+  .tagline {
+    font-size: 1.125rem;
+  }
+
+  .btn-download {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+
+  .hero-nav {
+    flex-wrap: wrap;
+    gap: 0.75rem 1.25rem;
+  }
+
+  .hero-quote {
+    font-size: 1.0625rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-download {
+    transition: none;
+  }
+  .btn-download:hover,
+  .btn-download:focus-visible {
+    transform: none;
+  }
+}
+
+/* ================================================================
+   Section A — Reframe Band (full-bleed accent)
+   ================================================================ */
+
+.reframe-band {
+  background-color: var(--accent);
+  color: #f4f6f4;
+}
+
+.reframe-inner {
+  padding: 4rem 1.5rem;
+  text-align: center;
+}
+
+.reframe-statement {
+  font-size: clamp(1.5rem, 3.5vw, 2.125rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #f4f6f4;
+  max-width: 680px;
+  margin: 0 auto 1.25rem;
+  line-height: 1.25;
+}
+
+.reframe-sub {
+  font-size: 1.125rem;
+  line-height: 1.7;
+  color: rgba(244, 246, 244, 0.85);
+  max-width: 680px;
+  margin: 0 auto;
+}
+
+@media (max-width: 767px) {
+  .reframe-statement {
+    font-size: 1.375rem;
+  }
+  .reframe-sub {
+    font-size: 1rem;
+  }
+}
+
+/* ================================================================
+   Section B — Stat Band
+   ================================================================ */
+
+.stat-band {
+  background-color: var(--surface);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.stat-band .section-inner {
+  padding: 4rem 1.5rem;
+}
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 1rem;
+  text-align: center;
+}
+
+.stat-item {
+  padding: 1.5rem 0.75rem;
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.stat-value {
+  display: block;
+  font-size: 1.875rem;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+  margin-bottom: 0.5rem;
+  line-height: 1.1;
+}
+
+.stat-label {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+.stat-disclaimer {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  text-align: center;
+  margin-top: 1.25rem;
+}
+
+@media (max-width: 900px) {
+  .stat-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 767px) {
+  .stat-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.75rem;
+  }
+  .stat-grid .stat-item:last-child {
+    grid-column: 1 / -1;
+  }
+  .stat-value {
+    font-size: 1.5rem;
+  }
+}
+
+/* ================================================================
+   Section C — Three Pillars
+   ================================================================ */
+
+.pillars .section-inner {
+  padding: 0;
+}
+
+.pillar-row {
+  display: grid;
+  grid-template-columns: 1fr 340px;
+  gap: 3rem;
+  align-items: start;
+  padding: 5rem 1.5rem;
+  max-width: 1100px;
+  margin: 0 auto;
+  border-bottom: 1px solid var(--border);
+}
+
+.pillar-row:last-child {
+  border-bottom: none;
+}
+
+/* Alternate: metrics panel on the left */
+.pillar-row-reverse {
+  grid-template-columns: 340px 1fr;
+  background-color: var(--surface);
+}
+
+.pillar-row-reverse .pillar-text {
+  order: 2;
+}
+
+.pillar-row-reverse .pillar-metrics-panel {
+  order: 1;
+}
+
+/* ---- Pillar text side ---- */
+
+.pillar-header {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+}
+
+.pillar-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  background-color: var(--accent);
+  color: #f4f6f4;
+  border-radius: 10px;
+  font-size: 1rem;
+  font-weight: 700;
+  flex-shrink: 0;
+  letter-spacing: 0.02em;
+}
+
+.pillar-text .section-heading {
+  margin-bottom: 0;
+}
+
+.pillar-text p {
+  font-size: 1.0625rem;
+  color: var(--text-secondary);
+  line-height: 1.75;
+  margin-bottom: 1.125rem;
+}
+
+.pillar-text p:last-of-type {
+  margin-bottom: 0;
+}
+
+.pillar-cta {
+  margin-top: 1.75rem;
+}
+
+/* ---- Metrics panel (card) ---- */
+
+.pillar-metrics-panel {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.pillar-row-reverse .pillar-metrics-panel {
+  background-color: var(--bg);
+}
+
+.metric-row {
+  padding: 1.125rem 0;
+  border-bottom: 1px solid var(--border);
+}
+
+.metric-row:first-child {
+  padding-top: 0;
+}
+
+.metric-row:last-child {
+  padding-bottom: 0;
+  border-bottom: none;
+}
+
+.metric-value {
+  display: block;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--accent);
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+  margin-bottom: 0.25rem;
+}
+
+.metric-label {
+  display: block;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.45;
+}
+
+@media (max-width: 900px) {
+  .pillar-row,
+  .pillar-row-reverse {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+    padding: 3.5rem 1.25rem;
+  }
+
+  .pillar-row-reverse .pillar-text {
+    order: 1;
+  }
+
+  .pillar-row-reverse .pillar-metrics-panel {
+    order: 2;
+  }
+
+  .pillar-metrics-panel {
+    max-width: 480px;
+  }
+}
+
+@media (max-width: 767px) {
+  .pillar-metrics-panel {
+    max-width: 100%;
+  }
+}
+
+/* ================================================================
+   Section D — Social Proof
+   ================================================================ */
+
+.social-proof {
+  background-color: var(--surface);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.quote-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1.5rem;
+  margin-bottom: 3rem;
+}
+
+.quote-card {
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 0 12px 12px 0;
+  padding: 1.75rem;
+}
+
+.quote-card blockquote {
+  margin: 0 0 1rem;
+  font-size: 0.9375rem;
+  line-height: 1.75;
+  color: var(--text-primary);
+  font-style: italic;
+}
+
+.quote-card cite {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  font-style: normal;
+}
+
+.outcome-table-wrap {
+  overflow-x: auto;
+}
+
+.outcome-table-heading {
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.5rem;
+}
+
+.outcome-table-disclaimer {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  margin-bottom: 1rem;
+}
+
+.outcome-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9375rem;
+}
+
+.outcome-table thead th {
+  background-color: var(--accent);
+  color: #f4f6f4;
+  padding: 0.625rem 1rem;
+  text-align: left;
+  font-weight: 600;
+}
+
+.outcome-table tbody tr:nth-child(even) td {
+  background-color: var(--bg);
+}
+
+.outcome-table tbody tr:nth-child(odd) td {
+  background-color: var(--surface);
+}
+
+.outcome-table tbody td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid var(--border);
+  color: var(--text-secondary);
+  vertical-align: top;
+  line-height: 1.5;
+}
+
+.outcome-table tbody td:first-child {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+@media (max-width: 767px) {
+  .quote-grid {
+    grid-template-columns: 1fr;
+  }
+  .outcome-table-wrap {
+    font-size: 0.875rem;
+  }
+}
+
+/* ================================================================
+   Section E — Persona Grid + CTA
+   ================================================================ */
+
+.persona-section {
+  background-color: var(--bg);
+}
+
+.persona-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.125rem;
+  margin-bottom: 3.5rem;
+}
+
+.persona-card {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-top: 3px solid var(--accent);
+  border-radius: 12px;
+  padding: 1.625rem;
+  text-decoration: none;
+  display: block;
+  transition: box-shadow 0.15s ease, transform 0.1s ease;
+}
+
+.persona-card:hover,
+.persona-card:focus-visible {
+  box-shadow: 0 6px 20px rgba(47, 79, 62, 0.12);
+  transform: translateY(-2px);
+}
+
+.persona-card:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 3px;
+}
+
+.persona-card-tier {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--accent);
+  margin-bottom: 0.5rem;
+}
+
+.persona-card h3 {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.625rem;
+  line-height: 1.3;
+}
+
+.persona-card p {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  margin: 0;
+}
+
+.persona-card-arrow {
+  display: block;
+  margin-top: 1.125rem;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+/* ---- CTA row below persona grid ---- */
+
+.persona-cta-row {
+  text-align: center;
+}
+
+.persona-cta-note {
+  margin-top: 0.875rem;
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+}
+
+@media (max-width: 900px) {
+  .persona-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 767px) {
+  .persona-grid {
+    grid-template-columns: 1fr;
+  }
+  .persona-card:hover,
+  .persona-card:focus-visible {
+    transform: none;
+  }
+  .persona-cta-row .btn-download {
+    display: block;
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .persona-card {
+    transition: none;
+  }
+  .persona-card:hover,
+  .persona-card:focus-visible {
+    transform: none;
+  }
+}
+
+/* ================================================================
+   Requirements block (shared — used on CTA bands and persona pages)
+   ================================================================ */
+
+.requirements {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 2rem;
+  margin-top: 1rem;
+}
+
+.requirements h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  margin-bottom: 1rem;
+}
+
+.requirements ul {
+  list-style: none;
+  padding: 0;
+}
+
+.requirements li {
+  padding: 0.375rem 0;
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  border-bottom: 1px solid var(--border);
+}
+
+.requirements li:last-child {
+  border-bottom: none;
+}
+
+.requirements li strong {
+  color: var(--text-primary);
+}
+
+.requirements li em {
+  color: var(--accent);
+  font-style: normal;
+}
+
+@media (max-width: 767px) {
+  .requirements {
+    padding: 1.5rem;
+  }
+}
+
+/* ================================================================
+   Footer
+   ================================================================ */
+
+footer {
+  border-top: 1px solid var(--border);
+  padding: 1.75rem 1.5rem;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.footer-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.footer-copy {
+  margin: 0;
+}
+
+.footer-nav {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+footer a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+footer a:hover,
+footer a:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+footer a:focus-visible {
+  outline: 2px solid var(--accent-hover);
+  outline-offset: 2px;
+  border-radius: 2px;
+}
+
+@media (max-width: 600px) {
+  .footer-inner {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.875rem;
+  }
+  .footer-nav {
+    gap: 0.75rem 1.25rem;
+  }
+}
+
+/* ================================================================
+   Persona Page Layout (shared across /for/* pages)
+   ================================================================ */
 
 .persona-hero {
   background-color: var(--accent);
@@ -1100,7 +1100,9 @@ footer a:focus-visible {
   }
 }
 
-/* ---- Value Props List ---- */
+/* ================================================================
+   Value Props List (shared — used on persona pages)
+   ================================================================ */
 
 .value-props {
   list-style: none;
@@ -1150,24 +1152,9 @@ footer a:focus-visible {
   margin: 0;
 }
 
-/* ---- Section Headings ---- */
-
-.section-heading {
-  font-size: 1.75rem;
-  font-weight: 700;
-  letter-spacing: -0.02em;
-  color: var(--text-primary);
-  margin-bottom: 0.5rem;
-}
-
-.section-subheading {
-  font-size: 1.0625rem;
-  color: var(--text-secondary);
-  max-width: 600px;
-  margin-bottom: 0;
-}
-
-/* ---- Capability Table ---- */
+/* ================================================================
+   Capability Table (shared — compare pages)
+   ================================================================ */
 
 .capability-table-wrap {
   overflow-x: auto;
@@ -1211,7 +1198,9 @@ footer a:focus-visible {
   font-weight: 600;
 }
 
-/* ---- Breadcrumb ---- */
+/* ================================================================
+   Breadcrumb (shared)
+   ================================================================ */
 
 .breadcrumb {
   font-size: 0.8125rem;
@@ -1234,7 +1223,9 @@ footer a:focus-visible {
   margin: 0 0.375rem;
 }
 
-/* ---- How It Works Full Page ---- */
+/* ================================================================
+   How It Works Full Page (shared)
+   ================================================================ */
 
 .hiw-narrative {
   max-width: 740px;
@@ -1296,14 +1287,15 @@ footer a:focus-visible {
   margin: 0;
 }
 
-/* ---- Footer nav extensions ---- */
-
-.footer-nav-extended {
-  display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 1rem 1.5rem;
+@media (max-width: 767px) {
+  .hiw-full-step {
+    flex-direction: column;
+  }
 }
+
+/* ================================================================
+   Footer section label (shared — guide pages)
+   ================================================================ */
 
 .footer-section-label {
   font-size: 0.75rem;
@@ -1312,10 +1304,4 @@ footer a:focus-visible {
   letter-spacing: 0.06em;
   color: var(--text-secondary);
   margin-bottom: 0.5rem;
-}
-
-@media (max-width: 767px) {
-  .hiw-full-step {
-    flex-direction: column;
-  }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -436,9 +436,41 @@ h1 {
    Section A — Reframe Band (full-bleed accent)
    ================================================================ */
 
-.reframe-band {
-  background-color: var(--accent);
+.reframe-band,
+.cta-band {
+  background-color: var(--accent) !important;
   color: #f4f6f4;
+}
+
+.cta-band .section-inner {
+  text-align: center;
+  padding: 4rem 1.5rem;
+}
+
+.cta-band h2 {
+  font-size: clamp(1.5rem, 3.5vw, 2.125rem);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: #f4f6f4;
+  margin-bottom: 1rem;
+}
+
+.cta-band p {
+  color: rgba(244, 246, 244, 0.85);
+  max-width: 560px;
+  margin: 0 auto 1.75rem;
+}
+
+.cta-band .btn-download {
+  background-color: #f4f6f4;
+  color: var(--accent);
+  border-color: #f4f6f4;
+}
+
+.cta-band .btn-download:hover,
+.cta-band .btn-download:focus-visible {
+  background-color: #ffffff;
+  border-color: #ffffff;
 }
 
 .reframe-inner {
@@ -607,6 +639,7 @@ h1 {
 
 .pillar-text .section-heading {
   margin-bottom: 0;
+  font-size: clamp(1.25rem, 2.5vw, 1.5rem);
 }
 
 .pillar-text p {
@@ -970,6 +1003,24 @@ footer {
   color: var(--text-secondary);
 }
 
+footer > p {
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+.footer-nav-extended {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem 1.5rem;
+  margin-top: 0.875rem;
+  max-width: 1100px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 .footer-inner {
   max-width: 1100px;
   margin: 0 auto;
@@ -1287,6 +1338,49 @@ footer a:focus-visible {
   margin: 0;
 }
 
+.hiw-steps {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.25rem;
+}
+
+.hiw-step {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.75rem 1.5rem;
+}
+
+.hiw-step-number {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+
+.hiw-step h3 {
+  font-size: 1.0625rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.625rem;
+  line-height: 1.3;
+}
+
+.hiw-step p {
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+  line-height: 1.6;
+  margin: 0;
+}
+
+@media (max-width: 767px) {
+  .hiw-steps {
+    grid-template-columns: 1fr;
+  }
+}
+
 @media (max-width: 767px) {
   .hiw-full-step {
     flex-direction: column;
@@ -1304,4 +1398,199 @@ footer a:focus-visible {
   letter-spacing: 0.06em;
   color: var(--text-secondary);
   margin-bottom: 0.5rem;
+}
+
+/* ================================================================
+   Architecture Diagram (security page)
+   ================================================================ */
+
+.arch-diagram {
+  margin: 2.5rem 0 1.5rem;
+  max-width: 560px;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  position: relative;
+}
+
+.arch-tier {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+}
+
+.arch-tier-label {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--text-secondary);
+  width: 4.5rem;
+  flex-shrink: 0;
+  text-align: right;
+}
+
+.arch-tier-box {
+  flex: 1;
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.875rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.arch-tier-box strong {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.arch-tier-note {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+/* Remote tier — slightly different border treatment */
+.arch-tier--remote .arch-tier-box {
+  border-color: var(--border);
+  background-color: var(--bg);
+}
+
+/* Local tiers — accent left border */
+.arch-tier--local .arch-tier-box {
+  border-left: 3px solid var(--accent);
+  background-color: var(--surface);
+}
+
+/* Isolated container — stronger accent treatment */
+.arch-tier-box--isolated {
+  border-left: 3px solid var(--accent) !important;
+  background-color: rgba(47, 79, 62, 0.05) !important;
+}
+
+/* External tier */
+.arch-tier--external .arch-tier-box {
+  background-color: var(--bg);
+}
+
+/* Connector rows between tiers */
+.arch-connector {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+  padding: 0.25rem 0;
+}
+
+.arch-connector-arrow {
+  font-size: 1rem;
+  color: var(--accent);
+  width: 4.5rem;
+  text-align: right;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.arch-connector-desc {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  font-style: italic;
+}
+
+/* Credential store — offset callout below the diagram */
+.arch-credential-store {
+  margin-top: 1rem;
+  padding-left: calc(4.5rem + 0.875rem);
+}
+
+.arch-credential-box {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background-color: var(--bg);
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 0.75rem 1.125rem;
+}
+
+.arch-credential-box::before {
+  content: "← ";
+  font-size: 0.8125rem;
+  color: var(--accent);
+}
+
+.arch-credential-box strong {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+/* Legend */
+.arch-legend {
+  display: flex;
+  gap: 1.25rem;
+  margin-top: 1.25rem;
+  flex-wrap: wrap;
+  padding-left: calc(4.5rem + 0.875rem);
+}
+
+.arch-legend-item {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  padding: 0.2rem 0.625rem;
+  border-radius: 4px;
+}
+
+.arch-legend-remote {
+  background-color: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+
+.arch-legend-local {
+  background-color: rgba(47, 79, 62, 0.08);
+  border: 1px solid var(--accent);
+  color: var(--accent);
+}
+
+.arch-legend-external {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-secondary);
+}
+
+/* Value props 2-column grid variant (security page) */
+.value-props--grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+}
+
+.value-props--grid .value-prop-item {
+  display: block;
+}
+
+@media (max-width: 767px) {
+  .value-props--grid {
+    grid-template-columns: 1fr;
+  }
+
+  .arch-legend {
+    padding-left: 0;
+  }
+
+  .arch-credential-store {
+    padding-left: 0;
+  }
+
+  .arch-tier-label {
+    width: 3.5rem;
+    font-size: 0.625rem;
+  }
+
+  .arch-connector-arrow {
+    width: 3.5rem;
+  }
 }

--- a/download/index.html
+++ b/download/index.html
@@ -4,8 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Download Prosponsive — macOS &amp; Windows</title>
-  <meta name="description" content="Download Prosponsive for macOS or Windows. Your personal autonomous agent platform — AI that works while you don't.">
+  <meta name="description" content="Download Prosponsive free for macOS or Windows. Personal autonomous agent platform — AI agents run tools in the background while you're away, data stays local.">
   <link rel="canonical" href="https://prosponsive.ai/download/">
+  <meta property="og:title" content="Download Prosponsive — macOS &amp; Windows">
+  <meta property="og:description" content="Download Prosponsive free for macOS or Windows. Personal autonomous agent platform — AI agents run tools in the background while you're away, data stays local.">
+  <meta property="og:url" content="https://prosponsive.ai/download/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Download Prosponsive — macOS &amp; Windows">
+  <meta name="twitter:description" content="Download Prosponsive free for macOS or Windows. Personal autonomous agent platform — AI agents run tools in the background while you're away, data stays local.">
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">

--- a/download/index.html
+++ b/download/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Download Prosponsive — macOS &amp; Windows</title>
+  <meta name="description" content="Download Prosponsive for macOS or Windows. Your personal autonomous agent platform — AI that works while you don't.">
+  <link rel="canonical" href="https://prosponsive.ai/download/">
+  <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
+  <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
+  <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://prosponsive.ai/download/#webpage",
+    "url": "https://prosponsive.ai/download/",
+    "name": "Download Prosponsive — macOS &amp; Windows",
+    "description": "Download Prosponsive for macOS or Windows. Your personal autonomous agent platform — AI that works while you don't.",
+    "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
+  }
+  </script>
+</head>
+<body class="page-wrapper">
+
+  <!-- ====================================================
+       Minimal Header
+  ==================================================== -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- ====================================================
+         Download Hero
+    ==================================================== -->
+    <section class="hero" aria-labelledby="download-heading">
+      <h1 id="download-heading" class="wordmark-heading">
+        <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
+      </h1>
+      <p class="tagline">AI That Works While You Don't</p>
+
+      <div class="download-cta" id="download">
+        <a
+          id="download-btn"
+          class="btn-download"
+          href="#"
+          aria-label="Download Prosponsive for macOS"
+        >
+          Download for macOS
+        </a>
+        <p id="version-info" class="version-info"></p>
+        <p id="platform-note" class="platform-note"></p>
+        <div class="platform-switch" aria-label="Choose platform">
+          <button type="button" data-platform="macos">macOS</button>
+          <button type="button" data-platform="windows">Windows</button>
+        </div>
+      </div>
+
+      <blockquote class="slack-quote">
+        <p>"If Slack was rebuilt autonomous agent first."</p>
+      </blockquote>
+    </section>
+
+    <!-- ====================================================
+         System Requirements
+    ==================================================== -->
+    <section class="requirements-section" aria-labelledby="requirements-heading">
+      <div class="section-inner">
+        <h2 id="requirements-heading" class="section-heading" style="text-align:center;margin-bottom:1.5rem;">System Requirements</h2>
+        <div class="requirements-grid">
+          <div class="requirement-item">
+            <h3>macOS</h3>
+            <p>macOS 12 Monterey or later</p>
+          </div>
+          <div class="requirement-item">
+            <h3>Windows</h3>
+            <p>Windows 10 or later</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+  <!-- ====================================================
+       Footer
+  ==================================================== -->
+  <footer>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/">Home</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script src="../js/download.js"></script>
+</body>
+</html>

--- a/for/consultants/index.html
+++ b/for/consultants/index.html
@@ -3,9 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Prosponsive for Consultants &amp; Independent Professionals — Set Up Once. Walk Away.</title>
-  <meta name="description" content="You shouldn't have to manage your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.">
+  <title>Prosponsive for Consultants — Set Up Once, Walk Away</title>
+  <meta name="description" content="Stop managing your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.">
   <link rel="canonical" href="https://prosponsive.ai/for/consultants/">
+  <meta property="og:title" content="Prosponsive for Consultants — Set Up Once, Walk Away">
+  <meta property="og:description" content="Stop managing your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.">
+  <meta property="og:url" content="https://prosponsive.ai/for/consultants/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Prosponsive for Consultants — Set Up Once, Walk Away">
+  <meta name="twitter:description" content="Stop managing your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.">
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -51,7 +59,6 @@
     <!-- Hero -->
     <section class="persona-hero" aria-labelledby="hero-heading">
       <div class="section-inner">
-        <div class="persona-hero-label">Independent Professional · Tier 1</div>
         <h1 id="hero-heading">Set up once. Assign work. Walk away.</h1>
         <p class="persona-hero-message">You shouldn't have to manage your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.</p>
         <div class="persona-hero-cta">
@@ -72,14 +79,14 @@
             <span class="value-prop-rank" aria-label="Priority 1">1</span>
             <div class="value-prop-content">
               <h3>Scheduled prompts + auto-approvals = recurring tasks run themselves</h3>
-              <p>Set up a workflow once — morning briefing, client digest, market monitoring, research synthesis — and Prosponsive runs it on schedule without you. Auto-approval rules let agents act within the bounds you define, without asking for confirmation at every step. Directional estimate: 3–7 hours per week on recurring tasks eliminated; 50–100+ daily interruptions removed via auto-approvals.</p>
+              <p>Set up a workflow once — morning briefing, client digest, market monitoring, research synthesis — and Prosponsive runs it on schedule without you. Auto-approval rules let agents act within the bounds you define, without asking for confirmation at every step. 3–7 hours per week on recurring tasks eliminated; 50–100+ daily interruptions removed via auto-approvals.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 2">2</span>
             <div class="value-prop-content">
               <h3>Async "task once, walk away"</h3>
-              <p>Post a task to a channel, assign it to an agent, and close the window. The agent runs tools asynchronously in the background — email, CRM, research, document generation — while you're in client meetings or focused on high-value work. Come back to completed results. Directional estimate: 30–90 min/day reclaimed from task babysitting; multi-step workflows reduced from hours to minutes.</p>
+              <p>Post a task to a channel, assign it to an agent, and close the window. The agent runs tools asynchronously in the background — Salesforce, NetSuite, Workday, ServiceNow — while you're in client meetings or focused on high-value work. Come back to completed results. 30–90 min/day reclaimed from task babysitting; multi-step workflows reduced from hours to minutes.</p>
             </div>
           </li>
           <li class="value-prop-item">
@@ -116,7 +123,7 @@
               <tr>
                 <td>Client research digest</td>
                 <td>Pulls company updates, press coverage, and LinkedIn activity for upcoming calls</td>
-                <td>Parallel agents + n8n web and CRM tools</td>
+                <td>Parallel agents + <a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> web and CRM tools</td>
               </tr>
               <tr>
                 <td>Proposal drafting</td>
@@ -136,22 +143,9 @@
             </tbody>
           </table>
         </div>
-        <p style="font-size:0.8125rem;color:var(--text-secondary);margin-top:0.75rem;">Directional estimates — results vary by workflow complexity and configuration.</p>
       </div>
     </section>
 
-    <!-- Social proof quote -->
-    <section aria-labelledby="proof-heading">
-      <div class="section-inner">
-        <h2 id="proof-heading" class="section-heading">From an early adopter</h2>
-        <div class="quote-block" style="max-width:680px;">
-          <blockquote>
-            "The thing that sold me wasn't the feature list — it was the first time I set up a scheduled prompt, walked away, and came back to a completed research brief. I hadn't clicked anything. I hadn't approved anything. It just ran. That's a different category of tool."
-          </blockquote>
-          <cite>— Early adopter &middot; Independent consultant &middot; Prosponsive beta user</cite>
-        </div>
-      </div>
-    </section>
 
     <!-- CTA Band -->
     <section class="cta-band" aria-labelledby="cta-heading">
@@ -166,19 +160,16 @@
   </main>
 
   <footer>
-    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
-    <nav class="footer-nav-extended" aria-label="Footer links">
-      <a href="/for/power-users/">For Developers</a>
-      <a href="/for/consultants/">For Consultants</a>
-      <a href="/for/privacy/">For Privacy</a>
-      <a href="/for/teams/">For Teams</a>
-      <a href="/how-it-works/">How It Works</a>
-      <a href="../../guides/user-guide.html">Guides</a>
-      <a href="../../releases/">Release Notes</a>
-      <a href="../../guides/compare/">Compare</a>
-      <a href="../../guides/feedback.html">Feedback</a>
-      <a href="/legal/">Legal</a>
-    </nav>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../../guides/user-guide.html">Guides</a>
+        <a href="../../guides/compare/">Compare</a>
+        <a href="../../releases/">Release Notes</a>
+        <a href="/legal/">Legal</a>
+      </nav>
+    </div>
   </footer>
 
 </body>

--- a/for/consultants/index.html
+++ b/for/consultants/index.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive for Consultants &amp; Independent Professionals — Set Up Once. Walk Away.</title>
+  <meta name="description" content="You shouldn't have to manage your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.">
+  <link rel="canonical" href="https://prosponsive.ai/for/consultants/">
+  <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
+  <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
+  <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://prosponsive.ai/for/consultants/#webpage",
+    "url": "https://prosponsive.ai/for/consultants/",
+    "name": "Prosponsive for Consultants & Independent Professionals",
+    "description": "You shouldn't have to manage your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes.",
+    "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Site Header -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="/for/power-users/">For Developers</a>
+        <a href="/for/consultants/" aria-current="page">For Consultants</a>
+        <a href="/for/privacy/">For Privacy</a>
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../../guides/user-guide.html">Guides</a>
+        <a href="/#download" class="nav-cta">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb section-inner" style="padding-top:1rem;padding-bottom:1rem;">
+      <a href="/">Home</a><span aria-hidden="true"> › </span>For Consultants &amp; Independent Professionals
+    </div>
+
+    <!-- Hero -->
+    <section class="persona-hero" aria-labelledby="hero-heading">
+      <div class="section-inner">
+        <div class="persona-hero-label">Independent Professional · Tier 1</div>
+        <h1 id="hero-heading">Set up once. Assign work. Walk away.</h1>
+        <p class="persona-hero-message">You shouldn't have to manage your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.</p>
+        <div class="persona-hero-cta">
+          <a href="/#download" class="btn-download">Download for macOS</a>
+          <a href="/how-it-works/" class="btn-secondary">See scheduled prompts</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Value Props -->
+    <section aria-labelledby="value-props-heading">
+      <div class="section-inner">
+        <h2 id="value-props-heading" class="section-heading">What matters most for you</h2>
+        <p class="section-subheading">Ranked by what independent professionals and consultants care about most — recurring automation, async results, and data on your machine.</p>
+
+        <ul class="value-props" role="list">
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 1">1</span>
+            <div class="value-prop-content">
+              <h3>Scheduled prompts + auto-approvals = recurring tasks run themselves</h3>
+              <p>Set up a workflow once — morning briefing, client digest, market monitoring, research synthesis — and Prosponsive runs it on schedule without you. Auto-approval rules let agents act within the bounds you define, without asking for confirmation at every step. Directional estimate: 3–7 hours per week on recurring tasks eliminated; 50–100+ daily interruptions removed via auto-approvals.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 2">2</span>
+            <div class="value-prop-content">
+              <h3>Async "task once, walk away"</h3>
+              <p>Post a task to a channel, assign it to an agent, and close the window. The agent runs tools asynchronously in the background — email, CRM, research, document generation — while you're in client meetings or focused on high-value work. Come back to completed results. Directional estimate: 30–90 min/day reclaimed from task babysitting; multi-step workflows reduced from hours to minutes.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 3">3</span>
+            <div class="value-prop-content">
+              <h3>Local data stays on your machine</h3>
+              <p>Your client documents, conversation history, credentials, and workflow data never leave your machine. Prosponsive runs entirely on your desktop — no cloud routing for your work. Your data stays with you, not with a provider. Encrypted locally. Offline-capable with local AI models.</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Use case examples -->
+    <section aria-labelledby="usecase-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="usecase-heading" class="section-heading">What consultants run on Prosponsive</h2>
+        <p class="section-subheading">Common recurring workflows that run automatically once configured — no babysitting required.</p>
+        <div class="capability-table-wrap">
+          <table class="capability-table">
+            <thead>
+              <tr>
+                <th>Workflow type</th>
+                <th>What it does</th>
+                <th>Architecture driver</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Morning briefing</td>
+                <td>Scans news, CRM updates, and email — surfaces what matters before your day starts</td>
+                <td>Scheduled prompts + async tool execution</td>
+              </tr>
+              <tr>
+                <td>Client research digest</td>
+                <td>Pulls company updates, press coverage, and LinkedIn activity for upcoming calls</td>
+                <td>Parallel agents + n8n web and CRM tools</td>
+              </tr>
+              <tr>
+                <td>Proposal drafting</td>
+                <td>Generates first-draft proposals from past work, client context, and template agents</td>
+                <td>Channel scoping + document tools</td>
+              </tr>
+              <tr>
+                <td>Invoice and follow-up tracking</td>
+                <td>Monitors outstanding invoices and drafts follow-ups when thresholds are met</td>
+                <td>Scheduled prompts + auto-approvals</td>
+              </tr>
+              <tr>
+                <td>Competitor monitoring</td>
+                <td>Tracks competitor product changes, pricing, and announcements on a schedule</td>
+                <td>Scheduled prompts + n8n web tools</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p style="font-size:0.8125rem;color:var(--text-secondary);margin-top:0.75rem;">Directional estimates — results vary by workflow complexity and configuration.</p>
+      </div>
+    </section>
+
+    <!-- Social proof quote -->
+    <section aria-labelledby="proof-heading">
+      <div class="section-inner">
+        <h2 id="proof-heading" class="section-heading">From an early adopter</h2>
+        <div class="quote-block" style="max-width:680px;">
+          <blockquote>
+            "The thing that sold me wasn't the feature list — it was the first time I set up a scheduled prompt, walked away, and came back to a completed research brief. I hadn't clicked anything. I hadn't approved anything. It just ran. That's a different category of tool."
+          </blockquote>
+          <cite>— Early adopter &middot; Independent consultant &middot; Prosponsive beta user</cite>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA Band -->
+    <section class="cta-band" aria-labelledby="cta-heading">
+      <div class="section-inner">
+        <h2 id="cta-heading">Your recurring work. Automated.</h2>
+        <p>Set up once, assign work, walk away. Prosponsive is free to download for macOS and Windows.</p>
+        <a href="/#download" class="btn-download">Download for macOS</a>
+        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>
+    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav-extended" aria-label="Footer links">
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../../guides/user-guide.html">Guides</a>
+      <a href="../../releases/">Release Notes</a>
+      <a href="../../guides/compare/">Compare</a>
+      <a href="../../guides/feedback.html">Feedback</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </footer>
+
+</body>
+</html>

--- a/for/consultants/index.html
+++ b/for/consultants/index.html
@@ -22,7 +22,7 @@
   }
   </script>
 </head>
-<body>
+<body class="page-wrapper">
 
   <!-- Site Header -->
   <header class="site-header">

--- a/for/power-users/index.html
+++ b/for/power-users/index.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive for Developers &amp; Power Users — Close the Orchestration Gap</title>
+  <meta name="description" content="Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover. Built for people who know what they actually want from AI.">
+  <link rel="canonical" href="https://prosponsive.ai/for/power-users/">
+  <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
+  <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
+  <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://prosponsive.ai/for/power-users/#webpage",
+    "url": "https://prosponsive.ai/for/power-users/",
+    "name": "Prosponsive for Developers & Power Users",
+    "description": "Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover.",
+    "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Site Header -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="/for/power-users/" aria-current="page">For Developers</a>
+        <a href="/for/consultants/">For Consultants</a>
+        <a href="/for/privacy/">For Privacy</a>
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../../guides/user-guide.html">Guides</a>
+        <a href="/#download" class="nav-cta">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb section-inner" style="padding-top:1rem;padding-bottom:1rem;">
+      <a href="/">Home</a><span aria-hidden="true"> › </span>For Power Users &amp; Developers
+    </div>
+
+    <!-- Hero -->
+    <section class="persona-hero" aria-labelledby="hero-heading">
+      <div class="section-inner">
+        <div class="persona-hero-label">Developer / Power User · Tier 1</div>
+        <h1 id="hero-heading">Your AI stack still has you as the orchestrator.</h1>
+        <p class="persona-hero-message">Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover. Built for people who know what they actually want from AI.</p>
+        <div class="persona-hero-cta">
+          <a href="/#download" class="btn-download">Download for macOS</a>
+          <a href="../../guides/compare/vs-cloud-chat.html" class="btn-secondary">Compare to MCP stacks</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Value Props -->
+    <section aria-labelledby="value-props-heading">
+      <div class="section-inner">
+        <h2 id="value-props-heading" class="section-heading">What matters most for you</h2>
+        <p class="section-subheading">Ranked by what power users and developers care about most — the orchestration gap, credential hygiene, and real tool depth.</p>
+
+        <ul class="value-props" role="list">
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 1">1</span>
+            <div class="value-prop-content">
+              <h3>Async parallel agents close the orchestration gap</h3>
+              <p>Stop being the context-passing middleware. Prosponsive runs multiple specialized agents in parallel channels — each one executing tools asynchronously in the background. You post a task and walk away. Results are waiting when you return. No more sitting at your desk approving every tool call, copying context between conversations, and manually sequencing steps. Directional estimate: 30–90 min/day reclaimed from task babysitting.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 2">2</span>
+            <div class="value-prop-content">
+              <h3>Credential isolation for production systems</h3>
+              <p>Your API keys are encrypted locally and isolated from every AI provider — they never touch a model or leave your machine. Each channel can be scoped to specific tool sets, so production credentials stay separated from dev workflows. Your secrets never touch an AI provider. Zero credential exposure by architecture, not by policy.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 3">3</span>
+            <div class="value-prop-content">
+              <h3>Provider-agnostic with automatic failover</h3>
+              <p>7+ AI providers supported in a single platform. Switch providers per channel, per task, or per cost budget — rebuild nothing. If one model goes down, Prosponsive automatically fails over to the next. Directional estimate: 20–40% cost optimization through provider switching; 100% of single-provider downtime eliminated via automatic failover.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 4">4</span>
+            <div class="value-prop-content">
+              <h3>n8n multi-system tools vs. single MCP calls</h3>
+              <p>Instead of one MCP call per system, n8n workflows orchestrate across multiple systems in a single agent tool call. Read a ticket, look up the customer, check billing, and draft the response — as one operation. 2,533 pre-built integrations across 216 products. Directional estimate: 60–80% fewer tool calls vs. equivalent MCP stacks; 5–10× faster than custom API development.</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Capability Table -->
+    <section aria-labelledby="capability-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="capability-heading" class="section-heading">Architecture comparison</h2>
+        <p class="section-subheading">How Prosponsive's architecture addresses the gaps in MCP-based stacks and cloud AI tools.</p>
+        <div class="capability-table-wrap">
+          <table class="capability-table">
+            <thead>
+              <tr>
+                <th>Capability</th>
+                <th>MCP / Cloud AI</th>
+                <th>Prosponsive</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Parallel agent execution</td>
+                <td>Sequential only — one tool call at a time</td>
+                <td>Multiple agents run simultaneously in channels</td>
+              </tr>
+              <tr>
+                <td>Async background execution</td>
+                <td>Synchronous — you wait for every step</td>
+                <td>Async — tools execute in the background</td>
+              </tr>
+              <tr>
+                <td>Credential isolation</td>
+                <td>Keys passed to model / cloud-routed</td>
+                <td>Encrypted locally — never touch an AI provider</td>
+              </tr>
+              <tr>
+                <td>Multi-system tool calls</td>
+                <td>One MCP server per system, sequential</td>
+                <td>n8n orchestrates multiple systems per call</td>
+              </tr>
+              <tr>
+                <td>Provider failover</td>
+                <td>Manual switch, rebuild required</td>
+                <td>Automatic — one setting, no rebuild</td>
+              </tr>
+              <tr>
+                <td>Auto-approval rules</td>
+                <td>Every call requires human approval</td>
+                <td>Define rules; agents act unattended within bounds</td>
+              </tr>
+              <tr>
+                <td>Data residency</td>
+                <td>Cloud-routed by default</td>
+                <td>100% local execution — offline-capable</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- Social proof quote -->
+    <section aria-labelledby="proof-heading">
+      <div class="section-inner">
+        <h2 id="proof-heading" class="section-heading">From an early adopter</h2>
+        <div class="quote-block" style="max-width:680px;">
+          <blockquote>
+            "I was already running Claude with a stack of MCP servers. I thought I had figured out AI automation — until I realized I was still sitting at my desk approving every tool call, copying context between conversations, and manually sequencing the steps. Prosponsive was the first platform where the agents actually worked without me."
+          </blockquote>
+          <cite>— Early adopter &middot; Software engineer &middot; Independent power user</cite>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA Band -->
+    <section class="cta-band" aria-labelledby="cta-heading">
+      <div class="section-inner">
+        <h2 id="cta-heading">Close the orchestration loop.</h2>
+        <p>Download Prosponsive and run your first parallel agent workflow in minutes. macOS and Windows, free to download.</p>
+        <a href="/#download" class="btn-download">Download for macOS</a>
+        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>
+    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav-extended" aria-label="Footer links">
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../../guides/user-guide.html">Guides</a>
+      <a href="../../releases/">Release Notes</a>
+      <a href="../../guides/compare/">Compare</a>
+      <a href="../../guides/feedback.html">Feedback</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </footer>
+
+</body>
+</html>

--- a/for/power-users/index.html
+++ b/for/power-users/index.html
@@ -3,9 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Prosponsive for Developers &amp; Power Users — Close the Orchestration Gap</title>
-  <meta name="description" content="Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover. Built for people who know what they actually want from AI.">
+  <title>Prosponsive for Developers &amp; Power Users</title>
+  <meta name="description" content="Your AI stack still has you as the orchestrator. Prosponsive closes the gap — parallel agents, async tools, credential isolation, and automatic failover. Local-first.">
   <link rel="canonical" href="https://prosponsive.ai/for/power-users/">
+  <meta property="og:title" content="Prosponsive for Developers &amp; Power Users">
+  <meta property="og:description" content="Your AI stack still has you as the orchestrator. Prosponsive closes the gap — parallel agents, async tools, credential isolation, and automatic failover. Local-first.">
+  <meta property="og:url" content="https://prosponsive.ai/for/power-users/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Prosponsive for Developers &amp; Power Users">
+  <meta name="twitter:description" content="Your AI stack still has you as the orchestrator. Prosponsive closes the gap — parallel agents, async tools, credential isolation, and automatic failover. Local-first.">
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -51,7 +59,6 @@
     <!-- Hero -->
     <section class="persona-hero" aria-labelledby="hero-heading">
       <div class="section-inner">
-        <div class="persona-hero-label">Developer / Power User · Tier 1</div>
         <h1 id="hero-heading">Your AI stack still has you as the orchestrator.</h1>
         <p class="persona-hero-message">Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover. Built for people who know what they actually want from AI.</p>
         <div class="persona-hero-cta">
@@ -72,28 +79,28 @@
             <span class="value-prop-rank" aria-label="Priority 1">1</span>
             <div class="value-prop-content">
               <h3>Async parallel agents close the orchestration gap</h3>
-              <p>Stop being the context-passing middleware. Prosponsive runs multiple specialized agents in parallel channels — each one executing tools asynchronously in the background. You post a task and walk away. Results are waiting when you return. No more sitting at your desk approving every tool call, copying context between conversations, and manually sequencing steps. Directional estimate: 30–90 min/day reclaimed from task babysitting.</p>
+              <p>Stop being the context-passing middleware. Prosponsive runs multiple specialized agents in parallel channels — each one executing tools asynchronously in the background. You post a task and walk away. Results are waiting when you return. No more sitting at your desk approving every tool call, copying context between conversations, and manually sequencing steps.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 2">2</span>
             <div class="value-prop-content">
               <h3>Credential isolation for production systems</h3>
-              <p>Your API keys are encrypted locally and isolated from every AI provider — they never touch a model or leave your machine. Each channel can be scoped to specific tool sets, so production credentials stay separated from dev workflows. Your secrets never touch an AI provider. Zero credential exposure by architecture, not by policy.</p>
+              <p>Your API keys are encrypted locally with least-privilege access. They are never transmitted to AI model providers or stored server-side. When an agent executes a tool, it informs the tool runtime — an isolated container with its own storage — which executes the tool and returns only the result. The tool runtime is a black box to the agent runtime. Credentials never leave it.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 3">3</span>
             <div class="value-prop-content">
               <h3>Provider-agnostic with automatic failover</h3>
-              <p>7+ AI providers supported in a single platform. Switch providers per channel, per task, or per cost budget — rebuild nothing. If one model goes down, Prosponsive automatically fails over to the next. Directional estimate: 20–40% cost optimization through provider switching; 100% of single-provider downtime eliminated via automatic failover.</p>
+              <p>7+ AI providers supported in a single platform. Switch providers per channel, per task, or per cost budget — rebuild nothing. If one model goes down, Prosponsive automatically fails over to the next.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 4">4</span>
             <div class="value-prop-content">
-              <h3>n8n multi-system tools vs. single MCP calls</h3>
-              <p>Instead of one MCP call per system, n8n workflows orchestrate across multiple systems in a single agent tool call. Read a ticket, look up the customer, check billing, and draft the response — as one operation. 2,533 pre-built integrations across 216 products. Directional estimate: 60–80% fewer tool calls vs. equivalent MCP stacks; 5–10× faster than custom API development.</p>
+              <h3><a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> multi-system tools vs. single MCP calls</h3>
+              <p>Instead of a separate AI call for every read, write, or lookup, n8n workflows orchestrate across multiple systems in a single agent tool call — read a ticket, look up the customer, check billing, and draft the response as one operation. Traditional tool calls are one-to-one with actions; Prosponsive collapses them into a single orchestrated step. Start with 2,533 pre-built integrations across 216 products out of the box and build your own with a visual workflow designer.</p>
             </div>
           </li>
         </ul>
@@ -157,17 +164,6 @@
     </section>
 
     <!-- Social proof quote -->
-    <section aria-labelledby="proof-heading">
-      <div class="section-inner">
-        <h2 id="proof-heading" class="section-heading">From an early adopter</h2>
-        <div class="quote-block" style="max-width:680px;">
-          <blockquote>
-            "I was already running Claude with a stack of MCP servers. I thought I had figured out AI automation — until I realized I was still sitting at my desk approving every tool call, copying context between conversations, and manually sequencing the steps. Prosponsive was the first platform where the agents actually worked without me."
-          </blockquote>
-          <cite>— Early adopter &middot; Software engineer &middot; Independent power user</cite>
-        </div>
-      </div>
-    </section>
 
     <!-- CTA Band -->
     <section class="cta-band" aria-labelledby="cta-heading">
@@ -182,19 +178,16 @@
   </main>
 
   <footer>
-    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
-    <nav class="footer-nav-extended" aria-label="Footer links">
-      <a href="/for/power-users/">For Developers</a>
-      <a href="/for/consultants/">For Consultants</a>
-      <a href="/for/privacy/">For Privacy</a>
-      <a href="/for/teams/">For Teams</a>
-      <a href="/how-it-works/">How It Works</a>
-      <a href="../../guides/user-guide.html">Guides</a>
-      <a href="../../releases/">Release Notes</a>
-      <a href="../../guides/compare/">Compare</a>
-      <a href="../../guides/feedback.html">Feedback</a>
-      <a href="/legal/">Legal</a>
-    </nav>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../../guides/user-guide.html">Guides</a>
+        <a href="../../guides/compare/">Compare</a>
+        <a href="../../releases/">Release Notes</a>
+        <a href="/legal/">Legal</a>
+      </nav>
+    </div>
   </footer>
 
 </body>

--- a/for/power-users/index.html
+++ b/for/power-users/index.html
@@ -22,7 +22,7 @@
   }
   </script>
 </head>
-<body>
+<body class="page-wrapper">
 
   <!-- Site Header -->
   <header class="site-header">
@@ -56,7 +56,7 @@
         <p class="persona-hero-message">Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover. Built for people who know what they actually want from AI.</p>
         <div class="persona-hero-cta">
           <a href="/#download" class="btn-download">Download for macOS</a>
-          <a href="../../guides/compare/vs-cloud-chat.html" class="btn-secondary">Compare to MCP stacks</a>
+          <a href="../../guides/compare/vs-cloud-chat.html" class="btn-secondary">Compare to cloud AI</a>
         </div>
       </div>
     </section>

--- a/for/privacy/index.html
+++ b/for/privacy/index.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive for Privacy-Conscious Professionals — Data Sovereignty by Design</title>
+  <meta name="description" content="Sensitive work doesn't have to route through cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, not with a provider.">
+  <link rel="canonical" href="https://prosponsive.ai/for/privacy/">
+  <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
+  <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
+  <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://prosponsive.ai/for/privacy/#webpage",
+    "url": "https://prosponsive.ai/for/privacy/",
+    "name": "Prosponsive for Privacy-Conscious Professionals",
+    "description": "Sensitive work doesn't have to route through cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, not with a provider.",
+    "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Site Header -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="/for/power-users/">For Developers</a>
+        <a href="/for/consultants/">For Consultants</a>
+        <a href="/for/privacy/" aria-current="page">For Privacy</a>
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../../guides/user-guide.html">Guides</a>
+        <a href="/#download" class="nav-cta">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb section-inner" style="padding-top:1rem;padding-bottom:1rem;">
+      <a href="/">Home</a><span aria-hidden="true"> › </span>For Privacy-Conscious Professionals
+    </div>
+
+    <!-- Hero -->
+    <section class="persona-hero" aria-labelledby="hero-heading">
+      <div class="section-inner">
+        <div class="persona-hero-label">Privacy-Conscious Professional · Tier 1</div>
+        <h1 id="hero-heading">Sensitive work doesn't have to route through the cloud.</h1>
+        <p class="persona-hero-message">Sensitive work doesn't have to route through cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, not with a provider.</p>
+        <div class="persona-hero-cta">
+          <a href="/#download" class="btn-download">Download for macOS</a>
+          <a href="../../guides/security-architecture-whitepaper.html" class="btn-secondary">Read security architecture</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Value Props -->
+    <section aria-labelledby="value-props-heading">
+      <div class="section-inner">
+        <h2 id="value-props-heading" class="section-heading">What matters most for you</h2>
+        <p class="section-subheading">Ranked by what privacy-conscious professionals in legal, finance, HR, and healthcare-adjacent work need most — local execution, credential hygiene, and encrypted-at-rest data.</p>
+
+        <ul class="value-props" role="list">
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 1">1</span>
+            <div class="value-prop-content">
+              <h3>100% local execution — data sovereignty by design</h3>
+              <p>Prosponsive runs entirely on your desktop. Your conversation history, documents, credentials, and workflow data never leave your machine. There is no cloud routing for your content — the platform is built local-first, not cloud-first with a "privacy mode" bolted on. 100% local execution means data sovereignty by architecture, not by policy.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 2">2</span>
+            <div class="value-prop-content">
+              <h3>Credential isolation — your secrets never touch an AI provider</h3>
+              <p>API keys, passwords, and authentication tokens are encrypted locally and isolated from every AI provider. They never travel through the AI inference layer. When an agent executes a tool that requires credentials, those credentials are injected locally — the AI model sees only the result. Zero credential exposure by design.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 3">3</span>
+            <div class="value-prop-content">
+              <h3>Offline capability with local AI models</h3>
+              <p>When sensitive workflows require air-gap conditions or unreliable connectivity, Prosponsive supports local AI models (via Ollama) that run entirely on-device — no internet connection required for inference. Mix cloud providers for non-sensitive work and local models for sensitive workflows, in separate channels.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 4">4</span>
+            <div class="value-prop-content">
+              <h3>Encrypted at rest, in transit — no server-side storage</h3>
+              <p>Conversation history and workflow state are encrypted locally. There is no server-side storage of your work. Prosponsive never stores anything server-side — your data exists only on your machine. Read the full security architecture for implementation details.</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Architecture summary -->
+    <section aria-labelledby="arch-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="arch-heading" class="section-heading">The privacy architecture at a glance</h2>
+        <p class="section-subheading">Built differently from cloud AI tools — local-first means the architecture enforces privacy, not a checkbox setting.</p>
+        <div class="capability-table-wrap">
+          <table class="capability-table">
+            <thead>
+              <tr>
+                <th>Data type</th>
+                <th>Cloud AI tools</th>
+                <th>Prosponsive</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Conversation history</td>
+                <td>Stored on provider servers</td>
+                <td>Stored locally, encrypted at rest</td>
+              </tr>
+              <tr>
+                <td>Uploaded documents</td>
+                <td>Transmitted to cloud servers</td>
+                <td>Never leave your machine</td>
+              </tr>
+              <tr>
+                <td>API keys &amp; credentials</td>
+                <td>Passed through inference layer or stored in cloud</td>
+                <td>Encrypted locally — never touch an AI provider</td>
+              </tr>
+              <tr>
+                <td>Workflow data</td>
+                <td>Cloud-routed by default</td>
+                <td>Local execution only</td>
+              </tr>
+              <tr>
+                <td>AI inference</td>
+                <td>Cloud provider required</td>
+                <td>7+ cloud providers + local models (Ollama); offline-capable</td>
+              </tr>
+              <tr>
+                <td>Tool execution results</td>
+                <td>Returned via cloud infrastructure</td>
+                <td>Executed locally — results returned to local agent</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div style="margin-top:1.5rem;">
+          <a href="../../guides/security-architecture-whitepaper.html" class="btn-secondary">Read the full security architecture</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA Band -->
+    <section class="cta-band" aria-labelledby="cta-heading">
+      <div class="section-inner">
+        <h2 id="cta-heading">Your data stays with you.</h2>
+        <p>Prosponsive is the personal autonomous agent platform built for sensitive work. Local execution, credential isolation, offline capability — by design.</p>
+        <a href="/#download" class="btn-download">Download for macOS</a>
+        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>
+    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav-extended" aria-label="Footer links">
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../../guides/user-guide.html">Guides</a>
+      <a href="../../releases/">Release Notes</a>
+      <a href="../../guides/compare/">Compare</a>
+      <a href="../../guides/feedback.html">Feedback</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </footer>
+
+</body>
+</html>

--- a/for/privacy/index.html
+++ b/for/privacy/index.html
@@ -3,9 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Prosponsive for Privacy-Conscious Professionals — Data Sovereignty by Design</title>
-  <meta name="description" content="Sensitive work doesn't have to route through cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, not with a provider.">
+  <title>Prosponsive for Privacy-Conscious Professionals</title>
+  <meta name="description" content="Sensitive work doesn't need cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, never sent to a provider.">
   <link rel="canonical" href="https://prosponsive.ai/for/privacy/">
+  <meta property="og:title" content="Prosponsive for Privacy-Conscious Professionals">
+  <meta property="og:description" content="Sensitive work doesn't need cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, never sent to a provider.">
+  <meta property="og:url" content="https://prosponsive.ai/for/privacy/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Prosponsive for Privacy-Conscious Professionals">
+  <meta name="twitter:description" content="Sensitive work doesn't need cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, never sent to a provider.">
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -17,7 +25,7 @@
     "@id": "https://prosponsive.ai/for/privacy/#webpage",
     "url": "https://prosponsive.ai/for/privacy/",
     "name": "Prosponsive for Privacy-Conscious Professionals",
-    "description": "Sensitive work doesn't have to route through cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, not with a provider.",
+    "description": "Sensitive work doesn't need cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, never sent to a provider.",
     "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
   }
   </script>
@@ -51,12 +59,11 @@
     <!-- Hero -->
     <section class="persona-hero" aria-labelledby="hero-heading">
       <div class="section-inner">
-        <div class="persona-hero-label">Privacy-Conscious Professional · Tier 1</div>
         <h1 id="hero-heading">Sensitive work doesn't have to route through the cloud.</h1>
-        <p class="persona-hero-message">Sensitive work doesn't have to route through cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, not with a provider.</p>
+        <p class="persona-hero-message">Sensitive work doesn't need cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, never sent to a provider.</p>
         <div class="persona-hero-cta">
           <a href="/#download" class="btn-download">Download for macOS</a>
-          <a href="../../guides/security-architecture-whitepaper.html" class="btn-secondary">Read security architecture</a>
+          <a href="/security/" class="btn-secondary">Read security architecture</a>
         </div>
       </div>
     </section>
@@ -72,21 +79,21 @@
             <span class="value-prop-rank" aria-label="Priority 1">1</span>
             <div class="value-prop-content">
               <h3>100% local execution — data sovereignty by design</h3>
-              <p>Prosponsive runs entirely on your desktop. Your conversation history, documents, credentials, and workflow data never leave your machine. There is no cloud routing for your content — the platform is built local-first, not cloud-first with a "privacy mode" bolted on. 100% local execution means data sovereignty by architecture, not by policy.</p>
+              <p>Prosponsive runs entirely on your desktop. Your conversation history, documents, credentials, and workflow data are never sent to Prosponsive servers or anywhere else without you explicitly including them in AI inference or a tool call. There is no cloud routing for your content — the platform is built local-first, not cloud-first with a "privacy mode" bolted on. 100% local execution means data sovereignty by architecture, not by policy.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 2">2</span>
             <div class="value-prop-content">
               <h3>Credential isolation — your secrets never touch an AI provider</h3>
-              <p>API keys, passwords, and authentication tokens are encrypted locally and isolated from every AI provider. They never travel through the AI inference layer. When an agent executes a tool that requires credentials, those credentials are injected locally — the AI model sees only the result. Zero credential exposure by design.</p>
+              <p>API keys, passwords, and authentication tokens are encrypted locally with least-privilege access. They are never transmitted to AI model providers or stored server-side. When an agent executes a tool, it informs the tool runtime — an isolated container with its own storage — which executes the tool and returns only the result. The tool runtime is a black box to the agent runtime. Credentials never leave it.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 3">3</span>
             <div class="value-prop-content">
-              <h3>Offline capability with local AI models</h3>
-              <p>When sensitive workflows require air-gap conditions or unreliable connectivity, Prosponsive supports local AI models (via Ollama) that run entirely on-device — no internet connection required for inference. Mix cloud providers for non-sensitive work and local models for sensitive workflows, in separate channels.</p>
+              <h3>Local AI models — no data sent to a provider</h3>
+              <p>Prosponsive supports local AI models via Ollama, running entirely on-device. For sensitive work where no data should leave the machine at the inference layer, configure Prosponsive to use a local model and nothing is transmitted externally.</p>
             </div>
           </li>
           <li class="value-prop-item">
@@ -94,6 +101,7 @@
             <div class="value-prop-content">
               <h3>Encrypted at rest, in transit — no server-side storage</h3>
               <p>Conversation history and workflow state are encrypted locally. There is no server-side storage of your work. Prosponsive never stores anything server-side — your data exists only on your machine. Read the full security architecture for implementation details.</p>
+              <p>When you're ready to remove data, Prosponsive supports both soft delete (conversations are marked deleted and excluded from all views) and hard delete (permanently and irreversibly purge your local data). Because everything is local, a hard delete on your machine is a true hard delete — there is no server-side copy to recover from.</p>
             </div>
           </li>
         </ul>
@@ -138,7 +146,7 @@
               <tr>
                 <td>AI inference</td>
                 <td>Cloud provider required</td>
-                <td>7+ cloud providers + local models (Ollama); offline-capable</td>
+                <td>7+ cloud providers or local models (Ollama) — one configured at a time</td>
               </tr>
               <tr>
                 <td>Tool execution results</td>
@@ -149,7 +157,7 @@
           </table>
         </div>
         <div style="margin-top:1.5rem;">
-          <a href="../../guides/security-architecture-whitepaper.html" class="btn-secondary">Read the full security architecture</a>
+          <a href="/security/" class="btn-secondary">Read the full security architecture</a>
         </div>
       </div>
     </section>
@@ -158,7 +166,7 @@
     <section class="cta-band" aria-labelledby="cta-heading">
       <div class="section-inner">
         <h2 id="cta-heading">Your data stays with you.</h2>
-        <p>Prosponsive is the personal autonomous agent platform built for sensitive work. Local execution, credential isolation, offline capability — by design.</p>
+        <p>Prosponsive is the personal autonomous agent platform built for sensitive work. Local execution, credential isolation, and local AI model support — by design.</p>
         <a href="/#download" class="btn-download">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
@@ -167,19 +175,16 @@
   </main>
 
   <footer>
-    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
-    <nav class="footer-nav-extended" aria-label="Footer links">
-      <a href="/for/power-users/">For Developers</a>
-      <a href="/for/consultants/">For Consultants</a>
-      <a href="/for/privacy/">For Privacy</a>
-      <a href="/for/teams/">For Teams</a>
-      <a href="/how-it-works/">How It Works</a>
-      <a href="../../guides/user-guide.html">Guides</a>
-      <a href="../../releases/">Release Notes</a>
-      <a href="../../guides/compare/">Compare</a>
-      <a href="../../guides/feedback.html">Feedback</a>
-      <a href="/legal/">Legal</a>
-    </nav>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../../guides/user-guide.html">Guides</a>
+        <a href="../../guides/compare/">Compare</a>
+        <a href="../../releases/">Release Notes</a>
+        <a href="/legal/">Legal</a>
+      </nav>
+    </div>
   </footer>
 
 </body>

--- a/for/privacy/index.html
+++ b/for/privacy/index.html
@@ -22,7 +22,7 @@
   }
   </script>
 </head>
-<body>
+<body class="page-wrapper">
 
   <!-- Site Header -->
   <header class="site-header">

--- a/for/teams/index.html
+++ b/for/teams/index.html
@@ -3,9 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Prosponsive for IT &amp; Security Teams — Every AI Action Auditable</title>
-  <meta name="description" content="Every AI action auditable. Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.">
+  <title>Prosponsive for IT &amp; Security Teams — AI Actions Auditable</title>
+  <meta name="description" content="Every AI action auditable. Auto-approval rules define what agents can do unattended. Credentials never touch the AI provider. Local execution by design.">
   <link rel="canonical" href="https://prosponsive.ai/for/teams/">
+  <meta property="og:title" content="Prosponsive for IT &amp; Security Teams — AI Actions Auditable">
+  <meta property="og:description" content="Every AI action auditable. Auto-approval rules define what agents can do unattended. Credentials never touch the AI provider. Local execution by design.">
+  <meta property="og:url" content="https://prosponsive.ai/for/teams/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Prosponsive for IT &amp; Security Teams — AI Actions Auditable">
+  <meta name="twitter:description" content="Every AI action auditable. Auto-approval rules define what agents can do unattended. Credentials never touch the AI provider. Local execution by design.">
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -17,7 +25,7 @@
     "@id": "https://prosponsive.ai/for/teams/#webpage",
     "url": "https://prosponsive.ai/for/teams/",
     "name": "Prosponsive for IT & Security Teams",
-    "description": "Every AI action auditable. Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.",
+    "description": "Every AI action auditable. Auto-approval rules define what agents can do unattended. Credentials never touch the AI provider. Local execution by design.",
     "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
   }
   </script>
@@ -52,11 +60,10 @@
     <!-- Hero -->
     <section class="persona-hero" aria-labelledby="hero-heading">
       <div class="section-inner">
-        <div class="persona-hero-label">IT / Security Decision Maker · Secondary</div>
         <h1 id="hero-heading">Every AI action auditable.</h1>
-        <p class="persona-hero-message">Every AI action auditable. Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.</p>
+        <p class="persona-hero-message">Every AI action auditable. Auto-approval rules define what agents can do unattended. Credentials never touch the AI provider. Local execution by design.</p>
         <div class="persona-hero-cta">
-          <a href="../../guides/security-architecture-whitepaper.html" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
+          <a href="/security/" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
           <a href="/#download" class="btn-secondary">Download for macOS</a>
         </div>
       </div>
@@ -73,28 +80,28 @@
             <span class="value-prop-rank" aria-label="Priority 1">1</span>
             <div class="value-prop-content">
               <h3>Governance, audit trail + auto-approval boundaries</h3>
-              <p>Every AI action is auditable. Auto-approval rules define exactly what agents are permitted to do without human review — which tools, which operations, which scope. Actions outside those rules require explicit approval. The audit trail captures what each agent did, when, and with what credentials. You define the boundaries; agents operate within them.</p>
+              <p>Every AI action is auditable. Auto-approval rules define exactly what agents are permitted to do without human review — which tools, which operations, which scope. Rules can include LLM confidence thresholds: set a high threshold to auto-approve only when the model is confident, a low threshold to auto-deny when confidence falls short, and anything in between is proposed by the agent but requires manual review before execution. The audit trail captures what each agent did, when, and with what credentials. You define the boundaries; agents operate within them.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 2">2</span>
             <div class="value-prop-content">
               <h3>Credential isolation — secrets never touch an AI provider</h3>
-              <p>API keys, service account credentials, and authentication tokens are encrypted locally on the user's machine. They are never transmitted to AI model providers or stored server-side. When an agent executes a tool requiring credentials, those are injected locally — the inference layer never sees the secret. Zero credential exposure by architecture.</p>
+              <p>API keys, service account credentials, and authentication tokens are encrypted locally with least-privilege access. They are never transmitted to AI model providers or stored server-side. When an agent executes a tool, it informs the tool runtime — an isolated container with its own storage — which executes the tool and returns only the result. The tool runtime is a black box to the agent runtime. Credentials never leave it.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 3">3</span>
             <div class="value-prop-content">
               <h3>Local execution / data residency</h3>
-              <p>Prosponsive runs on the user's desktop. Conversation history, documents, and workflow data never leave the machine. 100% local execution means data residency is enforced by the architecture — not by a cloud provider's contractual commitment to a region. Offline-capable with local AI models for air-gap or restricted-network environments.</p>
+              <p>Prosponsive runs on the user's desktop. Conversation history, documents, and workflow data never leave the machine. 100% local execution means data residency is enforced by the architecture — not by a cloud provider's contractual commitment to a region.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <span class="value-prop-rank" aria-label="Priority 4">4</span>
             <div class="value-prop-content">
               <h3>Provider failover for operational continuity</h3>
-              <p>7+ AI providers supported with automatic failover. When a cloud AI provider has an outage, Prosponsive automatically switches to the configured fallback — zero manual intervention, no productivity loss. Directional estimate: 100% of single-provider downtime eliminated via automatic failover. Provider-agnostic design means no vendor lock-in for your users.</p>
+              <p>7+ AI providers supported with automatic failover. When a cloud AI provider has an outage, Prosponsive automatically switches to the configured fallback — zero manual intervention, no productivity loss. Anthropic goes down or you run out of credits? Your configured backup will immediately get used and Prosponsive will periodically re-check to switch back to Anthropic. Provider-agnostic design means no vendor lock-in for your users.</p>
             </div>
           </li>
         </ul>
@@ -142,15 +149,15 @@
                 <td>7+ providers; automatic failover; switch anytime</td>
               </tr>
               <tr>
-                <td>Offline / air-gap support</td>
-                <td>Internet required for all inference</td>
-                <td>Local AI models (Ollama) for air-gap environments</td>
+                <td>Data lifecycle controls</td>
+                <td>Deletion subject to provider retention policy</td>
+                <td>Soft delete (excluded from all views) or hard delete (permanent, unrecoverable purge of local data)</td>
               </tr>
             </tbody>
           </table>
         </div>
         <div style="margin-top:1.5rem;">
-          <a href="../../guides/security-architecture-whitepaper.html" class="btn-secondary">Read the full security architecture</a>
+          <a href="/security/" class="btn-secondary">Read the full security architecture</a>
         </div>
       </div>
     </section>
@@ -160,7 +167,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">AI governance built in, not bolted on.</h2>
         <p>Prosponsive is the personal autonomous agent platform where every AI action is auditable, credentials are isolated, and data never leaves the machine.</p>
-        <a href="../../guides/security-architecture-whitepaper.html" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
+        <a href="/security/" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Or <a href="/#download" style="color:rgba(244,246,244,0.85);">download Prosponsive</a> to evaluate directly &middot; macOS &amp; Windows</p>
       </div>
     </section>
@@ -168,19 +175,16 @@
   </main>
 
   <footer>
-    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
-    <nav class="footer-nav-extended" aria-label="Footer links">
-      <a href="/for/power-users/">For Developers</a>
-      <a href="/for/consultants/">For Consultants</a>
-      <a href="/for/privacy/">For Privacy</a>
-      <a href="/for/teams/">For Teams</a>
-      <a href="/how-it-works/">How It Works</a>
-      <a href="../../guides/user-guide.html">Guides</a>
-      <a href="../../releases/">Release Notes</a>
-      <a href="../../guides/compare/">Compare</a>
-      <a href="../../guides/feedback.html">Feedback</a>
-      <a href="/legal/">Legal</a>
-    </nav>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../../guides/user-guide.html">Guides</a>
+        <a href="../../guides/compare/">Compare</a>
+        <a href="../../releases/">Release Notes</a>
+        <a href="/legal/">Legal</a>
+      </nav>
+    </div>
   </footer>
 
 </body>

--- a/for/teams/index.html
+++ b/for/teams/index.html
@@ -1,0 +1,187 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Prosponsive for IT &amp; Security Teams — Every AI Action Auditable</title>
+  <meta name="description" content="Every AI action auditable. Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.">
+  <link rel="canonical" href="https://prosponsive.ai/for/teams/">
+  <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
+  <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
+  <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://prosponsive.ai/for/teams/#webpage",
+    "url": "https://prosponsive.ai/for/teams/",
+    "name": "Prosponsive for IT & Security Teams",
+    "description": "Every AI action auditable. Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.",
+    "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Site Header -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="/for/power-users/">For Developers</a>
+        <a href="/for/consultants/">For Consultants</a>
+        <a href="/for/privacy/">For Privacy</a>
+        <a href="/for/teams/" aria-current="page">For Teams</a>
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../../guides/user-guide.html">Guides</a>
+        <a href="/#download" class="nav-cta">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb section-inner" style="padding-top:1rem;padding-bottom:1rem;">
+      <a href="/">Home</a><span aria-hidden="true"> › </span>For IT &amp; Security Decision Makers
+    </div>
+
+    <!-- Hero -->
+    <section class="persona-hero" aria-labelledby="hero-heading">
+      <div class="section-inner">
+        <div class="persona-hero-label">IT / Security Decision Maker · Secondary</div>
+        <h1 id="hero-heading">Every AI action auditable.</h1>
+        <p class="persona-hero-message">Every AI action auditable. Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.</p>
+        <div class="persona-hero-cta">
+          <a href="../../guides/security-architecture-whitepaper.html" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
+          <a href="/#download" class="btn-secondary">Download for macOS</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Value Props -->
+    <section aria-labelledby="value-props-heading">
+      <div class="section-inner">
+        <h2 id="value-props-heading" class="section-heading">What matters most for you</h2>
+        <p class="section-subheading">Ranked by what IT and security decision makers evaluate most — governance, credential hygiene, data residency, and operational continuity.</p>
+
+        <ul class="value-props" role="list">
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 1">1</span>
+            <div class="value-prop-content">
+              <h3>Governance, audit trail + auto-approval boundaries</h3>
+              <p>Every AI action is auditable. Auto-approval rules define exactly what agents are permitted to do without human review — which tools, which operations, which scope. Actions outside those rules require explicit approval. The audit trail captures what each agent did, when, and with what credentials. You define the boundaries; agents operate within them.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 2">2</span>
+            <div class="value-prop-content">
+              <h3>Credential isolation — secrets never touch an AI provider</h3>
+              <p>API keys, service account credentials, and authentication tokens are encrypted locally on the user's machine. They are never transmitted to AI model providers or stored server-side. When an agent executes a tool requiring credentials, those are injected locally — the inference layer never sees the secret. Zero credential exposure by architecture.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 3">3</span>
+            <div class="value-prop-content">
+              <h3>Local execution / data residency</h3>
+              <p>Prosponsive runs on the user's desktop. Conversation history, documents, and workflow data never leave the machine. 100% local execution means data residency is enforced by the architecture — not by a cloud provider's contractual commitment to a region. Offline-capable with local AI models for air-gap or restricted-network environments.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <span class="value-prop-rank" aria-label="Priority 4">4</span>
+            <div class="value-prop-content">
+              <h3>Provider failover for operational continuity</h3>
+              <p>7+ AI providers supported with automatic failover. When a cloud AI provider has an outage, Prosponsive automatically switches to the configured fallback — zero manual intervention, no productivity loss. Directional estimate: 100% of single-provider downtime eliminated via automatic failover. Provider-agnostic design means no vendor lock-in for your users.</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- Governance summary -->
+    <section aria-labelledby="gov-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="gov-heading" class="section-heading">Governance controls at a glance</h2>
+        <p class="section-subheading">Prosponsive's local-first architecture delivers governance properties that cloud-routed AI tools cannot provide by design.</p>
+        <div class="capability-table-wrap">
+          <table class="capability-table">
+            <thead>
+              <tr>
+                <th>Governance requirement</th>
+                <th>Cloud AI / MCP stacks</th>
+                <th>Prosponsive</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Audit trail for AI actions</td>
+                <td>Provider-dependent; often unavailable for tool calls</td>
+                <td>Every agent action logged locally with tool, scope, and result</td>
+              </tr>
+              <tr>
+                <td>Auto-approval boundaries</td>
+                <td>Every tool call requires human approval, or all-or-nothing</td>
+                <td>Rule-based: define what agents can do unattended</td>
+              </tr>
+              <tr>
+                <td>Credential security</td>
+                <td>Keys passed to cloud provider or stored server-side</td>
+                <td>Encrypted locally — never transmitted to AI provider</td>
+              </tr>
+              <tr>
+                <td>Data residency</td>
+                <td>Cloud-routed; residency depends on provider contract</td>
+                <td>Machine-local; data never leaves the endpoint</td>
+              </tr>
+              <tr>
+                <td>Provider lock-in risk</td>
+                <td>Locked to one or two providers</td>
+                <td>7+ providers; automatic failover; switch anytime</td>
+              </tr>
+              <tr>
+                <td>Offline / air-gap support</td>
+                <td>Internet required for all inference</td>
+                <td>Local AI models (Ollama) for air-gap environments</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <div style="margin-top:1.5rem;">
+          <a href="../../guides/security-architecture-whitepaper.html" class="btn-secondary">Read the full security architecture</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA Band -->
+    <section class="cta-band" aria-labelledby="cta-heading">
+      <div class="section-inner">
+        <h2 id="cta-heading">AI governance built in, not bolted on.</h2>
+        <p>Prosponsive is the personal autonomous agent platform where every AI action is auditable, credentials are isolated, and data never leaves the machine.</p>
+        <a href="../../guides/security-architecture-whitepaper.html" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
+        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Or <a href="/#download" style="color:rgba(244,246,244,0.85);">download Prosponsive</a> to evaluate directly &middot; macOS &amp; Windows</p>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>
+    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav-extended" aria-label="Footer links">
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../../guides/user-guide.html">Guides</a>
+      <a href="../../releases/">Release Notes</a>
+      <a href="../../guides/compare/">Compare</a>
+      <a href="../../guides/feedback.html">Feedback</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </footer>
+
+</body>
+</html>

--- a/for/teams/index.html
+++ b/for/teams/index.html
@@ -22,7 +22,7 @@
   }
   </script>
 </head>
-<body>
+<body class="page-wrapper">
 
   <!-- Site Header -->
   <header class="site-header">

--- a/how-it-works/index.html
+++ b/how-it-works/index.html
@@ -3,9 +3,17 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>How Prosponsive Works — The Bottleneck Isn't the Model. It's the Architecture.</title>
-  <meta name="description" content="Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. The full 2-minute picture.">
+  <title>How Prosponsive Works — Prosponsive</title>
+  <meta name="description" content="The bottleneck isn't the AI model — it's the architecture. Prosponsive runs agents in parallel, executes tools locally, and keeps your data on your machine.">
   <link rel="canonical" href="https://prosponsive.ai/how-it-works/">
+  <meta property="og:title" content="How Prosponsive Works — Prosponsive">
+  <meta property="og:description" content="The bottleneck isn't the AI model — it's the architecture. Prosponsive runs agents in parallel, executes tools locally, and keeps your data on your machine.">
+  <meta property="og:url" content="https://prosponsive.ai/how-it-works/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="How Prosponsive Works — Prosponsive">
+  <meta name="twitter:description" content="The bottleneck isn't the AI model — it's the architecture. Prosponsive runs agents in parallel, executes tools locally, and keeps your data on your machine.">
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
@@ -64,11 +72,11 @@
     <!-- The Problem -->
     <section aria-labelledby="problem-heading">
       <div class="section-inner">
-        <h2 id="problem-heading" class="section-heading">The problem with how you're using AI today</h2>
+        <h2 id="problem-heading" class="section-heading">The problem with how AI is used today</h2>
         <div class="hiw-narrative">
           <p>Most knowledge workers are doing the same thing: they've got ChatGPT in one tab, Claude in another, maybe Zapier running in the background — and they're manually stitching it all together. They're copying context between conversations, sitting and watching while tools process one step at a time, and wondering why their "AI-powered workflow" still feels like a lot of work.</p>
           <p>Here's what they're often missing: <strong>the bottleneck isn't the AI model. It's the architecture around it.</strong></p>
-          <p>Most tools are built synchronously — you wait. They're built for one provider — you're locked in. And your data passes through cloud servers you don't control.</p>
+          <p>Most AI tools are synchronous — you type and then you wait for your agent to let you participate again. It's one synchronous step at a time. They're built for one provider — you're locked in. And your data passes through cloud servers you don't control.</p>
         </div>
       </div>
     </section>
@@ -78,7 +86,7 @@
       <div class="section-inner">
         <h2 id="different-heading" class="section-heading">Prosponsive was built differently</h2>
         <div class="hiw-narrative">
-          <p>It runs on your desktop. Multiple specialized agents work in parallel inside channels, using tools that orchestrate across your real systems — email, CRM, databases, Slack — not just one at a time, but as complete workflows.</p>
+          <p>It runs on your desktop. Multiple specialized agents work in parallel inside channels, using tools that orchestrate across your real systems — Salesforce, NetSuite, Workday, ServiceNow — not just one at a time, but as complete workflows.</p>
           <p><strong>You post a task and walk away.</strong> The agents run, tools execute in the background, and results are waiting when you return. Your credentials never touch an AI provider. And if one model goes down, it automatically fails over to the next.</p>
           <p>For knowledge workers who are serious about reclaiming their time and protecting their data, it's the difference between an AI assistant and an AI that actually works while you're not.</p>
         </div>
@@ -104,7 +112,7 @@
             <div class="hiw-full-step-icon" aria-hidden="true">2</div>
             <div class="hiw-full-step-content">
               <h3>Agents work in parallel</h3>
-              <p>Unlike cloud AI chat tools where you wait for one model to finish before the next step begins, Prosponsive runs multiple specialized agents simultaneously. One agent can be drafting while another is researching while a third is monitoring. Each runs on its own context without you as the passing mechanism between them. You're not the orchestrator anymore — the platform is. Parallel agent channels mean multi-step workflows that used to take hours can complete in minutes.</p>
+              <p>Unlike cloud AI chat tools where you wait for one response to finish before the next step begins, Prosponsive runs multiple specialized agents simultaneously. One agent can be drafting while another is researching while a third is monitoring. Each runs on its own context without you as the passing mechanism between them. You're not the orchestrator anymore — the platform is. Parallel agent channels mean multi-step workflows that used to take hours can complete in minutes.</p>
             </div>
           </div>
 
@@ -112,7 +120,7 @@
             <div class="hiw-full-step-icon" aria-hidden="true">3</div>
             <div class="hiw-full-step-content">
               <h3>Tools execute asynchronously — across real systems</h3>
-              <p>Prosponsive agents use n8n-powered tools that orchestrate across your real systems — email, CRM, databases, Slack, calendars, project management — not just one at a time, but as complete workflows in a single tool call. Instead of one MCP call per system, n8n workflows execute across multiple systems per agent invocation: read a ticket, look up the customer, check billing history, and draft the response as a single operation. Async execution means the tools run in the background while you focus elsewhere. Your credentials are encrypted locally and never touch the AI model — they're injected at execution time on your machine.</p>
+              <p>Prosponsive agents use <a href="https://n8n.io" target="_blank" rel="noopener">n8n</a>-powered tools that orchestrate across your real systems — Salesforce, NetSuite, Workday, ServiceNow, and hundreds more — not just one at a time, but as complete workflows in a single tool call. Instead of one MCP call per system, n8n workflows execute across multiple systems per agent invocation: read a ticket, look up the customer, check billing history, and draft the response as a single operation. Async execution means the tools run in the background while you focus elsewhere. Your credentials are encrypted and not accessible by the agent runtime.</p>
             </div>
           </div>
 
@@ -150,33 +158,12 @@
           </div>
 
         </div>
-        <p style="font-size:0.8125rem;color:var(--text-secondary);text-align:center;margin-top:1rem;">All metrics are directional estimates — validate before customer-facing ROI use.</p>
       </div>
     </section>
 
-    <!-- Quote -->
-    <section aria-labelledby="proof-heading">
-      <div class="section-inner">
-        <h2 id="proof-heading" class="section-heading">What it feels like in practice</h2>
-        <div class="quote-grid">
-          <div class="quote-block">
-            <blockquote>
-              "I was already running Claude with a stack of MCP servers. I thought I had figured out AI automation — until I realized I was still sitting at my desk approving every tool call, copying context between conversations, and manually sequencing the steps. Prosponsive was the first platform where the agents actually worked without me."
-            </blockquote>
-            <cite>— Early adopter &middot; Software engineer &middot; Independent power user</cite>
-          </div>
-          <div class="quote-block">
-            <blockquote>
-              "The thing that sold me wasn't the feature list — it was the first time I set up a scheduled prompt, walked away, and came back to a completed research brief. I hadn't clicked anything. I hadn't approved anything. It just ran. That's a different category of tool."
-            </blockquote>
-            <cite>— Early adopter &middot; Independent consultant &middot; Prosponsive beta user</cite>
-          </div>
-        </div>
-      </div>
-    </section>
 
     <!-- Persona routing -->
-    <section aria-labelledby="routing-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+    <section aria-labelledby="routing-heading" style="background-color:var(--bg);border-top:1px solid var(--border);">
       <div class="section-inner">
         <h2 id="routing-heading" class="section-heading">Find your path</h2>
         <p class="section-subheading">Prosponsive was built for different kinds of knowledge workers. Find what matters most for how you work.</p>
@@ -222,19 +209,16 @@
   </main>
 
   <footer>
-    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
-    <nav class="footer-nav-extended" aria-label="Footer links">
-      <a href="/for/power-users/">For Developers</a>
-      <a href="/for/consultants/">For Consultants</a>
-      <a href="/for/privacy/">For Privacy</a>
-      <a href="/for/teams/">For Teams</a>
-      <a href="/how-it-works/">How It Works</a>
-      <a href="../guides/user-guide.html">Guides</a>
-      <a href="../releases/">Release Notes</a>
-      <a href="../guides/compare/">Compare</a>
-      <a href="../guides/feedback.html">Feedback</a>
-      <a href="/legal/">Legal</a>
-    </nav>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../guides/user-guide.html">Guides</a>
+        <a href="../guides/compare/">Compare</a>
+        <a href="../releases/">Release Notes</a>
+        <a href="/legal/">Legal</a>
+      </nav>
+    </div>
   </footer>
 
 </body>

--- a/how-it-works/index.html
+++ b/how-it-works/index.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>How Prosponsive Works — The Bottleneck Isn't the Model. It's the Architecture.</title>
+  <meta name="description" content="Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. The full 2-minute picture.">
+  <link rel="canonical" href="https://prosponsive.ai/how-it-works/">
+  <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
+  <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
+  <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://prosponsive.ai/how-it-works/#webpage",
+    "url": "https://prosponsive.ai/how-it-works/",
+    "name": "How Prosponsive Works",
+    "description": "The bottleneck isn't the AI model. It's the architecture. Prosponsive was built differently — local, parallel, async.",
+    "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
+  }
+  </script>
+</head>
+<body>
+
+  <!-- Site Header -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="/for/power-users/">For Developers</a>
+        <a href="/for/consultants/">For Consultants</a>
+        <a href="/for/privacy/">For Privacy</a>
+        <a href="/how-it-works/" aria-current="page">How It Works</a>
+        <a href="../guides/user-guide.html">Guides</a>
+        <a href="/#download" class="nav-cta">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb section-inner" style="padding-top:1rem;padding-bottom:1rem;">
+      <a href="/">Home</a><span aria-hidden="true"> › </span>How It Works
+    </div>
+
+    <!-- Hero -->
+    <section class="persona-hero" aria-labelledby="hero-heading">
+      <div class="section-inner">
+        <div class="persona-hero-label">The full picture — 2-minute read</div>
+        <h1 id="hero-heading">The bottleneck isn't the model. It's the architecture.</h1>
+        <p class="persona-hero-message">Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. Here's why that matters and how it works.</p>
+        <div class="persona-hero-cta">
+          <a href="/#download" class="btn-download">Download for macOS</a>
+          <a href="../guides/user-guide.html" class="btn-secondary">Read the user guide</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- The Problem -->
+    <section aria-labelledby="problem-heading">
+      <div class="section-inner">
+        <h2 id="problem-heading" class="section-heading">The problem with how you're using AI today</h2>
+        <div class="hiw-narrative">
+          <p>Most knowledge workers are doing the same thing: they've got ChatGPT in one tab, Claude in another, maybe Zapier running in the background — and they're manually stitching it all together. They're copying context between conversations, sitting and watching while tools process one step at a time, and wondering why their "AI-powered workflow" still feels like a lot of work.</p>
+          <p>Here's what they're often missing: <strong>the bottleneck isn't the AI model. It's the architecture around it.</strong></p>
+          <p>Most tools are built synchronously — you wait. They're built for one provider — you're locked in. And your data passes through cloud servers you don't control.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Built Differently -->
+    <section aria-labelledby="different-heading" style="background-color:var(--surface);border-top:1px solid var(--border);border-bottom:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="different-heading" class="section-heading">Prosponsive was built differently</h2>
+        <div class="hiw-narrative">
+          <p>It runs on your desktop. Multiple specialized agents work in parallel inside channels, using tools that orchestrate across your real systems — email, CRM, databases, Slack — not just one at a time, but as complete workflows.</p>
+          <p><strong>You post a task and walk away.</strong> The agents run, tools execute in the background, and results are waiting when you return. Your credentials never touch an AI provider. And if one model goes down, it automatically fails over to the next.</p>
+          <p>For knowledge workers who are serious about reclaiming their time and protecting their data, it's the difference between an AI assistant and an AI that actually works while you're not.</p>
+        </div>
+      </div>
+    </section>
+
+    <!-- Step-by-step: Channels → Agents → Tools → Results -->
+    <section aria-labelledby="howsteps-heading">
+      <div class="section-inner">
+        <h2 id="howsteps-heading" class="section-heading">How it works, step by step</h2>
+        <p class="section-subheading">The coordination layer that makes "post a task and walk away" real.</p>
+
+        <div class="hiw-full-steps">
+          <div class="hiw-full-step">
+            <div class="hiw-full-step-icon" aria-hidden="true">1</div>
+            <div class="hiw-full-step-content">
+              <h3>Channels are the coordination layer</h3>
+              <p>Channels in Prosponsive work like Slack channels — but for agents, not people. You drop a task into a channel: "research this competitor," "draft Q2 client summary," "monitor pricing changes and alert me." Multiple specialized agents can live in the same channel, each focused on a different part of the work. Channels can be scoped to specific tool sets, AI providers, and approval rules — so production credentials stay separated from dev workflows, and sensitive tasks run in isolated contexts.</p>
+            </div>
+          </div>
+
+          <div class="hiw-full-step">
+            <div class="hiw-full-step-icon" aria-hidden="true">2</div>
+            <div class="hiw-full-step-content">
+              <h3>Agents work in parallel</h3>
+              <p>Unlike cloud AI chat tools where you wait for one model to finish before the next step begins, Prosponsive runs multiple specialized agents simultaneously. One agent can be drafting while another is researching while a third is monitoring. Each runs on its own context without you as the passing mechanism between them. You're not the orchestrator anymore — the platform is. Parallel agent channels mean multi-step workflows that used to take hours can complete in minutes.</p>
+            </div>
+          </div>
+
+          <div class="hiw-full-step">
+            <div class="hiw-full-step-icon" aria-hidden="true">3</div>
+            <div class="hiw-full-step-content">
+              <h3>Tools execute asynchronously — across real systems</h3>
+              <p>Prosponsive agents use n8n-powered tools that orchestrate across your real systems — email, CRM, databases, Slack, calendars, project management — not just one at a time, but as complete workflows in a single tool call. Instead of one MCP call per system, n8n workflows execute across multiple systems per agent invocation: read a ticket, look up the customer, check billing history, and draft the response as a single operation. Async execution means the tools run in the background while you focus elsewhere. Your credentials are encrypted locally and never touch the AI model — they're injected at execution time on your machine.</p>
+            </div>
+          </div>
+
+          <div class="hiw-full-step">
+            <div class="hiw-full-step-icon" aria-hidden="true">4</div>
+            <div class="hiw-full-step-content">
+              <h3>Results are waiting when you return</h3>
+              <p>There's no "watching the spinner." You post the task, close the channel, and go do something else. When you come back — in 10 minutes, an hour, or the next morning — the completed work is there. Scheduled prompts let recurring tasks run on a cadence you set: morning briefings, weekly digests, monitoring alerts. Auto-approval rules let agents act on those tasks without asking you to confirm every step, within the bounds you've defined. That's what "AI that works while you don't" actually means in practice.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- The Three Pillars summary -->
+    <section aria-labelledby="pillars-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="pillars-heading" class="section-heading">The three things that make this possible</h2>
+
+        <div class="hiw-steps" style="margin-top:1.5rem;">
+          <div class="hiw-step">
+            <div class="hiw-step-number" aria-hidden="true">01</div>
+            <h3>Reclaim your time</h3>
+            <p>Async tools, parallel agents, auto-approvals, and scheduled prompts eliminate task babysitting. 30–90 min/day reclaimed. 3–7 hrs/week on recurring tasks eliminated.</p>
+          </div>
+          <div class="hiw-step">
+            <div class="hiw-step-number" aria-hidden="true">02</div>
+            <h3>Protect your data</h3>
+            <p>100% local execution. Credential isolation. Automatic failover across 7+ providers. Your data never leaves your machine. Your secrets never touch an AI provider.</p>
+          </div>
+          <div class="hiw-step">
+            <div class="hiw-step-number" aria-hidden="true">03</div>
+            <h3>Real tool integration</h3>
+            <p>n8n workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products. 60–80% fewer tool calls vs. MCP.</p>
+          </div>
+          <div class="hiw-step">
+            <div class="hiw-step-number" aria-hidden="true">12</div>
+            <h3>12 languages supported</h3>
+            <p>Prosponsive is available in 12 languages. macOS and Windows. Free to download.</p>
+          </div>
+        </div>
+        <p style="font-size:0.8125rem;color:var(--text-secondary);text-align:center;margin-top:1rem;">All metrics are directional estimates — validate before customer-facing ROI use.</p>
+      </div>
+    </section>
+
+    <!-- Quote -->
+    <section aria-labelledby="proof-heading">
+      <div class="section-inner">
+        <h2 id="proof-heading" class="section-heading">What it feels like in practice</h2>
+        <div class="quote-grid">
+          <div class="quote-block">
+            <blockquote>
+              "I was already running Claude with a stack of MCP servers. I thought I had figured out AI automation — until I realized I was still sitting at my desk approving every tool call, copying context between conversations, and manually sequencing the steps. Prosponsive was the first platform where the agents actually worked without me."
+            </blockquote>
+            <cite>— Early adopter &middot; Software engineer &middot; Independent power user</cite>
+          </div>
+          <div class="quote-block">
+            <blockquote>
+              "The thing that sold me wasn't the feature list — it was the first time I set up a scheduled prompt, walked away, and came back to a completed research brief. I hadn't clicked anything. I hadn't approved anything. It just ran. That's a different category of tool."
+            </blockquote>
+            <cite>— Early adopter &middot; Independent consultant &middot; Prosponsive beta user</cite>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Persona routing -->
+    <section aria-labelledby="routing-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="routing-heading" class="section-heading">Find your path</h2>
+        <p class="section-subheading">Prosponsive was built for different kinds of knowledge workers. Find what matters most for how you work.</p>
+        <div class="persona-grid" style="grid-template-columns:repeat(2,1fr);">
+          <a href="/for/power-users/" class="persona-card">
+            <div class="persona-card-tier">Developer / Power User</div>
+            <h3>Close the orchestration gap</h3>
+            <p>Parallel agents, async tools, credential isolation, and automatic failover — for people who already know what they want from AI.</p>
+            <span class="persona-card-arrow">For developers and power users &rarr;</span>
+          </a>
+          <a href="/for/consultants/" class="persona-card">
+            <div class="persona-card-tier">Independent Professional</div>
+            <h3>Set up once. Walk away.</h3>
+            <p>Turn recurring tasks into automatic outcomes. Briefings, digests, monitoring — with your data staying on your machine.</p>
+            <span class="persona-card-arrow">For consultants and freelancers &rarr;</span>
+          </a>
+          <a href="/for/privacy/" class="persona-card">
+            <div class="persona-card-tier">Privacy-Conscious Professional</div>
+            <h3>Data sovereignty by design</h3>
+            <p>Sensitive work doesn't have to route through cloud servers. Local execution, credential isolation, encrypted at rest.</p>
+            <span class="persona-card-arrow">For legal, finance, HR, and healthcare &rarr;</span>
+          </a>
+          <a href="/for/teams/" class="persona-card">
+            <div class="persona-card-tier">IT / Security Decision Maker</div>
+            <h3>Every AI action auditable</h3>
+            <p>Auto-approval rules, credential isolation, local execution — governance built in, not bolted on.</p>
+            <span class="persona-card-arrow">For IT and security leaders &rarr;</span>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- CTA Band -->
+    <section class="cta-band" aria-labelledby="cta-heading">
+      <div class="section-inner">
+        <h2 id="cta-heading">AI That Works While You Don't</h2>
+        <p>Prosponsive is the personal autonomous agent platform that runs AI assistants locally on your desktop. Free to download for macOS and Windows. 7+ AI providers. 2,533 tools. 12 languages.</p>
+        <a href="/#download" class="btn-download">Download for macOS</a>
+        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows &middot; 12 languages</p>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>
+    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav-extended" aria-label="Footer links">
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../guides/user-guide.html">Guides</a>
+      <a href="../releases/">Release Notes</a>
+      <a href="../guides/compare/">Compare</a>
+      <a href="../guides/feedback.html">Feedback</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </footer>
+
+</body>
+</html>

--- a/how-it-works/index.html
+++ b/how-it-works/index.html
@@ -22,7 +22,7 @@
   }
   </script>
 </head>
-<body>
+<body class="page-wrapper">
 
   <!-- Site Header -->
   <header class="site-header">
@@ -148,11 +148,7 @@
             <h3>Real tool integration</h3>
             <p>n8n workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products. 60–80% fewer tool calls vs. MCP.</p>
           </div>
-          <div class="hiw-step">
-            <div class="hiw-step-number" aria-hidden="true">12</div>
-            <h3>12 languages supported</h3>
-            <p>Prosponsive is available in 12 languages. macOS and Windows. Free to download.</p>
-          </div>
+
         </div>
         <p style="font-size:0.8125rem;color:var(--text-secondary);text-align:center;margin-top:1rem;">All metrics are directional estimates — validate before customer-facing ROI use.</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
   }
   </script>
 </head>
-<body>
+<body class="page-wrapper">
 
   <!-- ====================================================
        Site Header

--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
   <main id="main-content">
 
     <!-- ====================================================
-         Block 1 — Hero
+         Hero
     ==================================================== -->
     <section class="hero" aria-labelledby="app-name">
       <h1 id="app-name" class="wordmark-heading">
@@ -113,24 +113,24 @@
     </section>
 
     <!-- ====================================================
-         Block 2 — Reframe Strip
+         Section A — Reframe (full-bleed accent band)
     ==================================================== -->
-    <section class="reframe-strip" aria-labelledby="reframe-heading">
-      <div class="section-inner">
-        <h2 id="reframe-heading" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">The AI productivity problem</h2>
-        <p>Everyone knows AI assistants can save time. But most knowledge workers are still switching between five different AI tabs, babysitting every task, and watching their screen while tools "think." We built Prosponsive so your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. It's what Slack would look like if it were built agent-first.</p>
+    <section class="reframe-band" aria-labelledby="reframe-heading">
+      <div class="section-inner reframe-inner">
+        <h2 id="reframe-heading" class="reframe-statement">Everyone knows AI can save time. Most are still babysitting it.</h2>
+        <p class="reframe-sub">Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. It's what Slack would look like if it were built agent-first.</p>
       </div>
     </section>
 
     <!-- ====================================================
-         Block 3 — Stat Bar
+         Section B — Stat Bar
     ==================================================== -->
-    <section class="stat-bar" aria-labelledby="stats-heading">
+    <section class="stat-band" aria-labelledby="stats-heading">
       <div class="section-inner">
-        <h2 id="stats-heading" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Key metrics</h2>
+        <h2 id="stats-heading" class="visually-hidden">Key metrics</h2>
         <div class="stat-grid" role="list">
           <div class="stat-item" role="listitem">
-            <span class="stat-value">30–90 Min</span>
+            <span class="stat-value">30–90 min</span>
             <span class="stat-label">Reclaimed daily from task babysitting</span>
           </div>
           <div class="stat-item" role="listitem">
@@ -143,180 +143,128 @@
           </div>
           <div class="stat-item" role="listitem">
             <span class="stat-value">100%</span>
-            <span class="stat-label">Local execution — data never leaves your machine</span>
+            <span class="stat-label">Local — data never leaves your machine</span>
           </div>
           <div class="stat-item" role="listitem">
             <span class="stat-value">50–100+</span>
-            <span class="stat-label">Daily interruptions eliminated via auto-approvals</span>
+            <span class="stat-label">Daily interruptions eliminated</span>
           </div>
         </div>
-        <p style="font-size:0.8125rem;color:var(--text-secondary);text-align:center;margin-top:1rem;">Directional estimates — validate before customer-facing ROI use.</p>
+        <p class="stat-disclaimer">Directional estimates — validate before customer-facing ROI use.</p>
       </div>
     </section>
 
     <!-- ====================================================
-         Block 4 — Pillar 01: Reclaim your time
+         Section C — Three Pillars
     ==================================================== -->
-    <section class="pillar-section" aria-labelledby="pillar01-heading">
+    <section class="pillars" aria-labelledby="pillars-heading">
       <div class="section-inner">
-        <div class="pillar-header">
-          <span class="pillar-number" aria-hidden="true">01</span>
-          <h2 id="pillar01-heading">Reclaim time from the coordination layer</h2>
-        </div>
-        <div class="pillar-body">
-          <p>Async tools, parallel agents, auto-approvals, and scheduled prompts eliminate task babysitting. Post a task and walk away. Results are waiting when you return.</p>
-          <p>Most AI tools are synchronous — you wait, one step at a time. Prosponsive runs multiple specialized agents in parallel channels, executing tools in the background while you focus on work that matters.</p>
-          <div class="pillar-metrics" aria-label="Pillar 01 metrics">
-            <span class="pillar-metric"><strong>30–90 min/day</strong> reclaimed from task babysitting</span>
-            <span class="pillar-metric"><strong>50–100+</strong> daily interruptions eliminated via auto-approvals</span>
-            <span class="pillar-metric"><strong>3–7 hrs/week</strong> on recurring tasks eliminated by scheduled prompts</span>
+        <h2 id="pillars-heading" class="visually-hidden">Three pillars</h2>
+
+        <!-- Pillar 01 -->
+        <div class="pillar-row">
+          <div class="pillar-text">
+            <div class="pillar-header">
+              <span class="pillar-number" aria-hidden="true">01</span>
+              <h3 class="section-heading">Reclaim time from the coordination layer</h3>
+            </div>
+            <p>Async tools, parallel agents, auto-approvals, and scheduled prompts eliminate task babysitting. Post a task and walk away. Results are waiting when you return.</p>
+            <p>Most AI tools are synchronous — you wait, one step at a time. Prosponsive runs multiple specialized agents in parallel channels, executing tools in the background while you focus on work that matters.</p>
+            <div class="pillar-cta">
+              <a href="/how-it-works/" class="btn-secondary">See how it works</a>
+            </div>
           </div>
-          <div class="pillar-cta">
-            <a href="/how-it-works/" class="btn-secondary">See how it works</a>
+          <div class="pillar-metrics-panel" aria-label="Pillar 01 metrics">
+            <div class="metric-row">
+              <span class="metric-value">30–90 min/day</span>
+              <span class="metric-label">reclaimed from task babysitting</span>
+            </div>
+            <div class="metric-row">
+              <span class="metric-value">50–100+</span>
+              <span class="metric-label">daily interruptions eliminated via auto-approvals</span>
+            </div>
+            <div class="metric-row">
+              <span class="metric-value">3–7 hrs/week</span>
+              <span class="metric-label">on recurring tasks eliminated by scheduled prompts</span>
+            </div>
           </div>
         </div>
+
+        <!-- Pillar 02 -->
+        <div class="pillar-row pillar-row-reverse">
+          <div class="pillar-text">
+            <div class="pillar-header">
+              <span class="pillar-number" aria-hidden="true">02</span>
+              <h3 class="section-heading">Protect your data, credentials &amp; continuity</h3>
+            </div>
+            <p>Local execution, credential isolation, automatic failover across 7+ providers, offline-capable. Your data never leaves your machine. Your secrets never touch an AI provider.</p>
+            <p>Sensitive work doesn't have to route through cloud servers. Prosponsive runs on your desktop — your documents, credentials, and workflows stay with you. And if one model goes down, it automatically fails over to the next.</p>
+            <div class="pillar-cta">
+              <a href="guides/security-architecture-whitepaper.html" class="btn-secondary">Read security architecture</a>
+            </div>
+          </div>
+          <div class="pillar-metrics-panel" aria-label="Pillar 02 metrics">
+            <div class="metric-row">
+              <span class="metric-value">100%</span>
+              <span class="metric-label">local execution — data sovereignty by design</span>
+            </div>
+            <div class="metric-row">
+              <span class="metric-value">Zero</span>
+              <span class="metric-label">credential exposure to AI providers</span>
+            </div>
+            <div class="metric-row">
+              <span class="metric-value">0 downtime</span>
+              <span class="metric-label">from single-provider outages via automatic failover</span>
+            </div>
+          </div>
+        </div>
+
+        <!-- Pillar 03 -->
+        <div class="pillar-row">
+          <div class="pillar-text">
+            <div class="pillar-header">
+              <span class="pillar-number" aria-hidden="true">03</span>
+              <h3 class="section-heading">Deploy real tool integration — not just conversation</h3>
+            </div>
+            <p>n8n workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products — one agent call executes a complete workflow: read a ticket, look up the customer, check billing, and draft the response as a single operation.</p>
+            <p>Not trigger-action automation. Not single MCP calls. Prosponsive agents use n8n-powered tools that coordinate across your real systems — email, CRM, databases, Slack — in one step, with 60–80% fewer tool calls compared to equivalent MCP stacks.</p>
+            <div class="pillar-cta">
+              <a href="guides/n8n-tool-building-guide.html" class="btn-secondary">Browse integrations</a>
+            </div>
+          </div>
+          <div class="pillar-metrics-panel" aria-label="Pillar 03 metrics">
+            <div class="metric-row">
+              <span class="metric-value">2,533 tools</span>
+              <span class="metric-label">across 216 products</span>
+            </div>
+            <div class="metric-row">
+              <span class="metric-value">60–80%</span>
+              <span class="metric-label">fewer tool calls vs. MCP</span>
+            </div>
+            <div class="metric-row">
+              <span class="metric-value">5–10×</span>
+              <span class="metric-label">faster than custom API development</span>
+            </div>
+          </div>
+        </div>
+
       </div>
     </section>
 
     <!-- ====================================================
-         Block 5 — Pillar 02: Protect your data & continuity
-    ==================================================== -->
-    <section class="pillar-section" aria-labelledby="pillar02-heading">
-      <div class="section-inner">
-        <div class="pillar-header">
-          <span class="pillar-number" aria-hidden="true">02</span>
-          <h2 id="pillar02-heading">Protect your data, credentials &amp; continuity</h2>
-        </div>
-        <div class="pillar-body">
-          <p>Local execution, credential isolation, automatic failover across 7+ providers, offline-capable. Your data never leaves your machine. Your secrets never touch an AI provider.</p>
-          <p>Sensitive work doesn't have to route through cloud servers. Prosponsive runs on your desktop — your documents, credentials, and workflows stay with you. And if one model goes down, it automatically fails over to the next.</p>
-          <div class="pillar-metrics" aria-label="Pillar 02 metrics">
-            <span class="pillar-metric"><strong>100%</strong> local execution — data sovereignty by design</span>
-            <span class="pillar-metric"><strong>Zero</strong> credential exposure to AI providers</span>
-            <span class="pillar-metric"><strong>0</strong> downtime from single-provider outages via automatic failover</span>
-          </div>
-          <div class="pillar-cta">
-            <a href="guides/security-architecture-whitepaper.html" class="btn-secondary">Read security architecture</a>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ====================================================
-         Block 6 — Pillar 03: Real tool integration
-    ==================================================== -->
-    <section class="pillar-section" aria-labelledby="pillar03-heading">
-      <div class="section-inner">
-        <div class="pillar-header">
-          <span class="pillar-number" aria-hidden="true">03</span>
-          <h2 id="pillar03-heading">Deploy real tool integration — not just conversation</h2>
-        </div>
-        <div class="pillar-body">
-          <p>n8n workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products — one agent call executes a complete workflow: read a ticket, look up the customer, check billing, and draft the response as a single operation.</p>
-          <p>Not trigger-action automation. Not single MCP calls. Prosponsive agents use n8n-powered tools that coordinate across your real systems — email, CRM, databases, Slack — in one step, with 60–80% fewer tool calls compared to equivalent MCP stacks.</p>
-          <div class="pillar-metrics" aria-label="Pillar 03 metrics">
-            <span class="pillar-metric"><strong>2,533 tools</strong> across 216 products</span>
-            <span class="pillar-metric"><strong>60–80%</strong> fewer tool calls vs. MCP</span>
-            <span class="pillar-metric"><strong>5–10×</strong> faster than custom API development</span>
-          </div>
-          <div class="pillar-cta">
-            <a href="guides/n8n-tool-building-guide.html" class="btn-secondary">Browse integrations</a>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ====================================================
-         Block 7 — How It Works (mini)
-    ==================================================== -->
-    <section class="how-it-works-mini" aria-labelledby="hiw-heading">
-      <div class="section-inner">
-        <h2 id="hiw-heading" class="section-heading" style="text-align:center;">How it works</h2>
-        <p class="section-subheading" style="text-align:center;margin:0 auto 0;">The bottleneck isn't the AI model. It's the architecture around it.</p>
-        <div class="hiw-steps">
-          <div class="hiw-step">
-            <div class="hiw-step-number" aria-hidden="true">1</div>
-            <h3>Post a task</h3>
-            <p>Drop your request into a channel. Assign it to one or more specialized agents.</p>
-          </div>
-          <div class="hiw-step">
-            <div class="hiw-step-number" aria-hidden="true">2</div>
-            <h3>Agents work in parallel</h3>
-            <p>Multiple agents run simultaneously in channels — your coordination layer.</p>
-          </div>
-          <div class="hiw-step">
-            <div class="hiw-step-number" aria-hidden="true">3</div>
-            <h3>Tools execute async</h3>
-            <p>Workflows connect your real systems — email, CRM, databases — in the background.</p>
-          </div>
-          <div class="hiw-step">
-            <div class="hiw-step-number" aria-hidden="true">4</div>
-            <h3>Results are waiting</h3>
-            <p>Come back to completed work. No babysitting. No approvals per step.</p>
-          </div>
-        </div>
-        <div class="hiw-link">
-          <a href="/how-it-works/" class="btn-secondary">See the full picture</a>
-        </div>
-      </div>
-    </section>
-
-    <!-- ====================================================
-         Block 8 — Persona Selector
-    ==================================================== -->
-    <section class="persona-selector" aria-labelledby="personas-heading">
-      <div class="section-inner">
-        <h2 id="personas-heading" class="section-heading">Built for your workflow</h2>
-        <p class="section-subheading">Find your fit — each path leads to what matters most for how you work.</p>
-        <div class="persona-grid">
-          <a href="/for/power-users/" class="persona-card">
-            <div class="persona-card-tier">Developer / Power User</div>
-            <h3>Close the orchestration gap</h3>
-            <p>Your AI stack still has you as the orchestrator. Parallel agents, async tools, credential isolation, and automatic failover — built for people who know what they want from AI.</p>
-            <span class="persona-card-arrow">For developers and power users &rarr;</span>
-          </a>
-          <a href="/for/consultants/" class="persona-card">
-            <div class="persona-card-tier">Independent Professional</div>
-            <h3>Set up once. Walk away.</h3>
-            <p>You shouldn't have to manage your AI. Turn recurring tasks into automatic outcomes — briefings, digests, monitoring — with your data staying on your machine.</p>
-            <span class="persona-card-arrow">For consultants and freelancers &rarr;</span>
-          </a>
-          <a href="/for/privacy/" class="persona-card">
-            <div class="persona-card-tier">Privacy-Conscious Professional</div>
-            <h3>Data sovereignty by design</h3>
-            <p>Sensitive work doesn't have to route through cloud servers. Your documents, credentials, and workflows stay with you — not with a provider.</p>
-            <span class="persona-card-arrow">For legal, finance, HR, and healthcare &rarr;</span>
-          </a>
-          <a href="/for/teams/" class="persona-card">
-            <div class="persona-card-tier">IT / Security Decision Maker</div>
-            <h3>Every AI action auditable</h3>
-            <p>Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.</p>
-            <span class="persona-card-arrow">For IT and security leaders &rarr;</span>
-          </a>
-          <a href="/how-it-works/" class="persona-card">
-            <div class="persona-card-tier">Curious Professional</div>
-            <h3>A team of specialists in a group chat</h3>
-            <p>AI should work while you don't. Drop a task and come back to results, not process. No code. No babysitting. Just outcomes.</p>
-            <span class="persona-card-arrow">See how Prosponsive works &rarr;</span>
-          </a>
-        </div>
-      </div>
-    </section>
-
-    <!-- ====================================================
-         Block 9 — Social Proof
+         Section D — Social Proof
     ==================================================== -->
     <section class="social-proof" aria-labelledby="proof-heading">
       <div class="section-inner">
-        <h2 id="proof-heading" class="section-heading">What early adopters are saying</h2>
+        <h2 id="proof-heading" class="section-heading" style="text-align:center;margin-bottom:2rem;">What early adopters are saying</h2>
         <div class="quote-grid">
-          <div class="quote-block">
+          <div class="quote-card">
             <blockquote>
               "I was already running Claude with a stack of MCP servers. I thought I had figured out AI automation — until I realized I was still sitting at my desk approving every tool call, copying context between conversations, and manually sequencing the steps. Prosponsive was the first platform where the agents actually worked without me."
             </blockquote>
             <cite>— Early adopter &middot; Software engineer &middot; Independent power user</cite>
           </div>
-          <div class="quote-block">
+          <div class="quote-card">
             <blockquote>
               "The thing that sold me wasn't the feature list — it was the first time I set up a scheduled prompt, walked away, and came back to a completed research brief. I hadn't clicked anything. I hadn't approved anything. It just ran. That's a different category of tool."
             </blockquote>
@@ -325,8 +273,8 @@
         </div>
 
         <div class="outcome-table-wrap">
-          <h3 style="font-size:1.125rem;font-weight:700;color:var(--text-primary);margin-bottom:1rem;">Results by user type</h3>
-          <p style="font-size:0.875rem;color:var(--text-secondary);margin-bottom:1rem;">Directional estimates based on observed usage patterns — validate before customer-facing ROI use.</p>
+          <h3 class="outcome-table-heading">Results by user type</h3>
+          <p class="outcome-table-disclaimer">Directional estimates based on observed usage patterns — validate before customer-facing ROI use.</p>
           <table class="outcome-table">
             <thead>
               <tr>
@@ -368,25 +316,46 @@
     </section>
 
     <!-- ====================================================
-         Block 10 — Competitive Teaser
+         Section E — Persona Grid + CTA
     ==================================================== -->
-    <section class="competitive-teaser" aria-labelledby="compare-heading">
+    <section class="persona-section" aria-labelledby="personas-heading">
       <div class="section-inner">
-        <h2 id="compare-heading">Already using Claude, GPT, or Zapier?</h2>
-        <p>Prosponsive is not a replacement for your AI subscriptions — it's the coordination layer that makes them work together, locally, in parallel. See how the architectures compare.</p>
-        <a href="guides/compare/" class="btn-secondary">Compare Prosponsive to alternatives</a>
-      </div>
-    </section>
+        <h2 id="personas-heading" class="section-heading" style="text-align:center;margin-bottom:0.5rem;">Built for your workflow</h2>
+        <p class="section-subheading" style="text-align:center;margin:0 auto 2.5rem;">Find your fit — each path leads to what matters most for how you work.</p>
+        <div class="persona-grid">
+          <a href="/for/power-users/" class="persona-card">
+            <div class="persona-card-tier">Developer / Power User</div>
+            <h3>Close the orchestration gap</h3>
+            <p>Your AI stack still has you as the orchestrator. Parallel agents, async tools, credential isolation, and automatic failover — built for people who know what they want from AI.</p>
+            <span class="persona-card-arrow">For developers and power users &rarr;</span>
+          </a>
+          <a href="/for/consultants/" class="persona-card">
+            <div class="persona-card-tier">Independent Professional</div>
+            <h3>Set up once. Walk away.</h3>
+            <p>You shouldn't have to manage your AI. Turn recurring tasks into automatic outcomes — briefings, digests, monitoring — with your data staying on your machine.</p>
+            <span class="persona-card-arrow">For consultants and freelancers &rarr;</span>
+          </a>
+          <a href="/for/privacy/" class="persona-card">
+            <div class="persona-card-tier">Privacy-Conscious Professional</div>
+            <h3>Data sovereignty by design</h3>
+            <p>Sensitive work doesn't have to route through cloud servers. Your documents, credentials, and workflows stay with you — not with a provider.</p>
+            <span class="persona-card-arrow">For legal, finance, HR, and healthcare &rarr;</span>
+          </a>
+          <a href="/for/teams/" class="persona-card">
+            <div class="persona-card-tier">IT / Security Decision Maker</div>
+            <h3>Every AI action auditable</h3>
+            <p>Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.</p>
+            <span class="persona-card-arrow">For IT and security leaders &rarr;</span>
+          </a>
+          <a href="/how-it-works/" class="persona-card">
+            <div class="persona-card-tier">Curious Professional</div>
+            <h3>A team of specialists in a group chat</h3>
+            <p>AI should work while you don't. Drop a task and come back to results, not process. No code. No babysitting. Just outcomes.</p>
+            <span class="persona-card-arrow">See how Prosponsive works &rarr;</span>
+          </a>
+        </div>
 
-    <!-- ====================================================
-         Block 11 — Final CTA Band
-    ==================================================== -->
-    <section class="cta-band" aria-labelledby="cta-heading">
-      <div class="section-inner">
-        <h2 id="cta-heading">AI That Works While You Don't</h2>
-        <p>Prosponsive is the personal autonomous agent platform that runs AI assistants locally on your desktop — so your agents actually work while you don't.</p>
-
-        <div class="download-area">
+        <div class="persona-cta-row">
           <a
             id="download-btn-footer"
             class="btn-download"
@@ -395,16 +364,8 @@
           >
             Download for macOS
           </a>
+          <p class="persona-cta-note">Free to download &middot; macOS &amp; Windows</p>
         </div>
-        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
-
-        <section class="requirements" aria-labelledby="req-heading">
-          <h2 id="req-heading">System Requirements</h2>
-          <ul>
-            <li><strong>macOS</strong> 12 (Monterey) or later — Apple Silicon (arm64)</li>
-            <li><strong>Windows</strong> 10 or later — x64 or ARM64</li>
-          </ul>
-        </section>
       </div>
     </section>
 
@@ -414,19 +375,16 @@
        Footer
   ==================================================== -->
   <footer>
-    <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
-    <nav class="footer-nav-extended" aria-label="Footer links">
-      <a href="/for/power-users/">For Developers</a>
-      <a href="/for/consultants/">For Consultants</a>
-      <a href="/for/privacy/">For Privacy</a>
-      <a href="/for/teams/">For Teams</a>
-      <a href="/how-it-works/">How It Works</a>
-      <a href="guides/user-guide.html">Guides</a>
-      <a href="releases/">Release Notes</a>
-      <a href="guides/compare/">Compare</a>
-      <a href="guides/feedback.html">Feedback</a>
-      <a href="/legal/">Legal</a>
-    </nav>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/how-it-works/">How It Works</a>
+        <a href="guides/user-guide.html">Guides</a>
+        <a href="guides/compare/">Compare</a>
+        <a href="releases/">Release Notes</a>
+        <a href="/legal/">Legal</a>
+      </nav>
+    </div>
   </footer>
 
   <script src="js/download.js"></script>

--- a/index.html
+++ b/index.html
@@ -4,8 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive — AI That Works While You Don't</title>
-  <meta name="description" content="Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. Personal autonomous agent platform for macOS and Windows.">
+  <meta name="description" content="Personal autonomous agent platform for macOS and Windows. AI agents run tools in the background, in parallel — your data stays on your machine.">
   <link rel="canonical" href="https://prosponsive.ai/">
+  <meta property="og:title" content="Prosponsive — AI That Works While You Don't">
+  <meta property="og:description" content="Personal autonomous agent platform for macOS and Windows. AI agents run tools in the background, in parallel — your data stays on your machine.">
+  <meta property="og:url" content="https://prosponsive.ai/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Prosponsive — AI That Works While You Don't">
+  <meta name="twitter:description" content="Personal autonomous agent platform for macOS and Windows. AI agents run tools in the background, in parallel — your data stays on your machine.">
   <link rel="icon" href="assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="assets/icon.png?v=2026-05-04">
@@ -89,7 +97,7 @@
     <section class="reframe-band" aria-labelledby="reframe-heading">
       <div class="section-inner reframe-inner">
         <h2 id="reframe-heading" class="reframe-statement">Everyone knows AI can save time.<br>Most are still babysitting it.</h2>
-        <p class="reframe-sub">Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine.</p>
+        <p class="reframe-sub">Prosponsive AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine.</p>
       </div>
     </section>
 
@@ -144,7 +152,7 @@
               <h3 class="section-heading">Reclaim time from the coordination layer</h3>
             </div>
             <p>Async tools, parallel agents, auto-approvals, and scheduled prompts eliminate task babysitting. Post a task and walk away. Results are waiting when you return.</p>
-            <p>Most AI tools are synchronous — you wait, one step at a time. Prosponsive runs multiple specialized agents in parallel channels, executing tools in the background while you focus on work that matters.</p>
+            <p>Most AI tools are synchronous — you type and then you wait for your agent to let you participate again. It's one synchronous step at a time. Prosponsive runs multiple specialized agents in parallel, executing tools in the background while you focus on work that matters.</p>
             <div class="pillar-cta">
               <a href="/how-it-works/" class="btn-secondary">See how it works</a>
             </div>
@@ -172,10 +180,9 @@
               <span class="pillar-number" aria-hidden="true">02</span>
               <h3 class="section-heading">Protect your data, credentials &amp; continuity</h3>
             </div>
-            <p>The agent runtime, tool execution, and storage all run on your machine. Your credentials never touch an AI provider. LLMs are remote and tools can call external APIs — but your files, keys, and workflow state stay local.</p>
-            <p>Sensitive work doesn't have to route through cloud servers. Prosponsive runs on your desktop — your documents, credentials, and workflows stay with you. And if one model goes down, it automatically fails over to the next.</p>
+            <p>The agent runtime, tool execution, and storage all run on your machine — your files, keys, and workflow state stay local even though LLMs are remote and tools can call external APIs. Your credentials never touch an AI provider. And if one model goes down, Prosponsive automatically fails over to the next.</p>
             <div class="pillar-cta">
-              <a href="guides/security-architecture-whitepaper.html" class="btn-secondary">Read security architecture</a>
+              <a href="/security/" class="btn-secondary">Read security architecture</a>
             </div>
           </div>
           <div class="pillar-metrics-panel" aria-label="Pillar 02 metrics">
@@ -201,8 +208,8 @@
               <span class="pillar-number" aria-hidden="true">03</span>
               <h3 class="section-heading">Deploy real tool integration — not just conversation</h3>
             </div>
-            <p>n8n workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products — one agent call executes a complete workflow: read a ticket, look up the customer, check billing, and draft the response as a single operation.</p>
-            <p>Not trigger-action automation. Not single MCP calls. Prosponsive agents use n8n-powered tools that coordinate across your real systems — email, CRM, databases, Slack — in one step, with 60–80% fewer tool calls compared to equivalent MCP stacks.</p>
+            <p><a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products — one agent call executes a complete workflow: read a ticket, look up the customer, check billing, and draft the response as a single operation.</p>
+            <p>Not trigger-action automation. Not single MCP calls. Prosponsive agents use n8n-powered tools that coordinate across your real systems — Salesforce, NetSuite, Workday, ServiceNow — in one step, with 60–80% fewer tool calls compared to equivalent MCP stacks.</p>
             <div class="pillar-cta">
               <a href="guides/n8n-tool-building-guide.html" class="btn-secondary">Browse integrations</a>
             </div>
@@ -266,10 +273,6 @@
           </a>
         </div>
 
-        <div class="persona-cta-row">
-          <a href="/download/" class="btn-download">Download free</a>
-          <p class="persona-cta-note">Free to download &middot; macOS &amp; Windows</p>
-        </div>
       </div>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
         <a href="/for/privacy/">For Privacy</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="guides/user-guide.html">Guides</a>
-        <a href="#download" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta">Download</a>
       </nav>
     </div>
   </header>
@@ -81,35 +81,6 @@
       </h1>
       <p class="tagline">AI That Works While You Don't</p>
 
-      <div class="download-area" id="download">
-        <a
-          id="download-btn"
-          class="btn-download"
-          href="#"
-          aria-label="Download Prosponsive for macOS"
-        >
-          Download for macOS
-        </a>
-        <p id="version-info" class="version-info" aria-live="polite"></p>
-      </div>
-
-      <p id="platform-note" class="platform-note" aria-live="polite"></p>
-      <p class="platform-switch">
-        See downloads for
-        <button type="button" class="link-btn" data-platform="macos">macOS</button>
-        or <button type="button" class="link-btn" data-platform="windows">Windows</button>.
-      </p>
-
-      <p class="hero-quote">
-        "If Slack was rebuilt autonomous agent first."
-      </p>
-      <nav class="hero-nav" aria-label="Quick links">
-        <a href="/how-it-works/">How It Works</a>
-        <a href="guides/user-guide.html">Guides</a>
-        <a href="releases/">Release Notes</a>
-        <a href="guides/feedback.html">Feedback</a>
-        <a href="/legal/">Legal</a>
-      </nav>
     </section>
 
     <!-- ====================================================
@@ -117,8 +88,8 @@
     ==================================================== -->
     <section class="reframe-band" aria-labelledby="reframe-heading">
       <div class="section-inner reframe-inner">
-        <h2 id="reframe-heading" class="reframe-statement">Everyone knows AI can save time. Most are still babysitting it.</h2>
-        <p class="reframe-sub">Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. It's what Slack would look like if it were built agent-first.</p>
+        <h2 id="reframe-heading" class="reframe-statement">Everyone knows AI can save time.<br>Most are still babysitting it.</h2>
+        <p class="reframe-sub">Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine.</p>
       </div>
     </section>
 
@@ -143,14 +114,18 @@
           </div>
           <div class="stat-item" role="listitem">
             <span class="stat-value">100%</span>
-            <span class="stat-label">Local — data never leaves your machine</span>
+            <span class="stat-label">Local runtime — your files &amp; keys stay on your machine</span>
           </div>
           <div class="stat-item" role="listitem">
             <span class="stat-value">50–100+</span>
             <span class="stat-label">Daily interruptions eliminated</span>
           </div>
+          <div class="stat-item" role="listitem">
+            <span class="stat-value">0%</span>
+            <span class="stat-label">Credential exposure to AI providers</span>
+          </div>
         </div>
-        <p class="stat-disclaimer">Directional estimates — validate before customer-facing ROI use.</p>
+
       </div>
     </section>
 
@@ -197,7 +172,7 @@
               <span class="pillar-number" aria-hidden="true">02</span>
               <h3 class="section-heading">Protect your data, credentials &amp; continuity</h3>
             </div>
-            <p>Local execution, credential isolation, automatic failover across 7+ providers, offline-capable. Your data never leaves your machine. Your secrets never touch an AI provider.</p>
+            <p>The agent runtime, tool execution, and storage all run on your machine. Your credentials never touch an AI provider. LLMs are remote and tools can call external APIs — but your files, keys, and workflow state stay local.</p>
             <p>Sensitive work doesn't have to route through cloud servers. Prosponsive runs on your desktop — your documents, credentials, and workflows stay with you. And if one model goes down, it automatically fails over to the next.</p>
             <div class="pillar-cta">
               <a href="guides/security-architecture-whitepaper.html" class="btn-secondary">Read security architecture</a>
@@ -206,7 +181,7 @@
           <div class="pillar-metrics-panel" aria-label="Pillar 02 metrics">
             <div class="metric-row">
               <span class="metric-value">100%</span>
-              <span class="metric-label">local execution — data sovereignty by design</span>
+              <span class="metric-label">local runtime — your files &amp; keys stay on your machine</span>
             </div>
             <div class="metric-row">
               <span class="metric-value">Zero</span>
@@ -252,70 +227,6 @@
     </section>
 
     <!-- ====================================================
-         Section D — Social Proof
-    ==================================================== -->
-    <section class="social-proof" aria-labelledby="proof-heading">
-      <div class="section-inner">
-        <h2 id="proof-heading" class="section-heading" style="text-align:center;margin-bottom:2rem;">What early adopters are saying</h2>
-        <div class="quote-grid">
-          <div class="quote-card">
-            <blockquote>
-              "I was already running Claude with a stack of MCP servers. I thought I had figured out AI automation — until I realized I was still sitting at my desk approving every tool call, copying context between conversations, and manually sequencing the steps. Prosponsive was the first platform where the agents actually worked without me."
-            </blockquote>
-            <cite>— Early adopter &middot; Software engineer &middot; Independent power user</cite>
-          </div>
-          <div class="quote-card">
-            <blockquote>
-              "The thing that sold me wasn't the feature list — it was the first time I set up a scheduled prompt, walked away, and came back to a completed research brief. I hadn't clicked anything. I hadn't approved anything. It just ran. That's a different category of tool."
-            </blockquote>
-            <cite>— Early adopter &middot; Independent consultant &middot; Prosponsive beta user</cite>
-          </div>
-        </div>
-
-        <div class="outcome-table-wrap">
-          <h3 class="outcome-table-heading">Results by user type</h3>
-          <p class="outcome-table-disclaimer">Directional estimates based on observed usage patterns — validate before customer-facing ROI use.</p>
-          <table class="outcome-table">
-            <thead>
-              <tr>
-                <th>User type</th>
-                <th>Outcome pattern</th>
-                <th>Architecture driver</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Power User / Developer</td>
-                <td>Recovered 60–90 min/day from task babysitting</td>
-                <td>Async tool execution + parallel agent channels</td>
-              </tr>
-              <tr>
-                <td>Independent Consultant</td>
-                <td>Recurring task setup eliminated (briefings, digests, monitoring run automatically)</td>
-                <td>Scheduled prompts + auto-approvals</td>
-              </tr>
-              <tr>
-                <td>Privacy-Conscious Professional</td>
-                <td>Moved sensitive workflows fully local, kept cloud providers for non-sensitive work</td>
-                <td>Local-first + credential isolation</td>
-              </tr>
-              <tr>
-                <td>Multi-Tool Power User</td>
-                <td>Consolidated 4 AI subscriptions into one platform</td>
-                <td>Provider-agnostic + channel scoping</td>
-              </tr>
-              <tr>
-                <td>Operations Manager</td>
-                <td>~70% per-task tool-call overhead reduction on multi-system workflows</td>
-                <td>n8n workflow tools + single-call orchestration</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </section>
-
-    <!-- ====================================================
          Section E — Persona Grid + CTA
     ==================================================== -->
     <section class="persona-section" aria-labelledby="personas-heading">
@@ -356,14 +267,7 @@
         </div>
 
         <div class="persona-cta-row">
-          <a
-            id="download-btn-footer"
-            class="btn-download"
-            href="#"
-            aria-label="Download Prosponsive for macOS"
-          >
-            Download for macOS
-          </a>
+          <a href="/download/" class="btn-download">Download free</a>
           <p class="persona-cta-note">Free to download &middot; macOS &amp; Windows</p>
         </div>
       </div>
@@ -387,24 +291,5 @@
     </div>
   </footer>
 
-  <script src="js/download.js"></script>
-  <script>
-    // Mirror the download button state to the footer CTA button
-    (function () {
-      function syncFooterBtn() {
-        var primaryBtn = document.getElementById('download-btn');
-        var footerBtn = document.getElementById('download-btn-footer');
-        if (!primaryBtn || !footerBtn) return;
-        footerBtn.href = primaryBtn.href;
-        footerBtn.textContent = primaryBtn.textContent;
-        footerBtn.setAttribute('aria-label', primaryBtn.getAttribute('aria-label') || primaryBtn.textContent);
-      }
-      // Sync after download.js runs (it fires on DOMContentLoaded + after fetch)
-      document.addEventListener('DOMContentLoaded', function () {
-        setTimeout(syncFooterBtn, 100);
-        setTimeout(syncFooterBtn, 2000);
-      });
-    })();
-  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Prosponsive — Personal Autonomous Agent Platform</title>
-  <meta name="description" content="Prosponsive is a personal autonomous agent platform that runs AI assistants locally on your desktop. Available for macOS and Windows.">
+  <title>Prosponsive — AI That Works While You Don't</title>
+  <meta name="description" content="Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. Personal autonomous agent platform for macOS and Windows.">
   <link rel="canonical" href="https://prosponsive.ai/">
   <link rel="icon" href="assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="assets/favicon.ico?v=2026-05-04">
@@ -35,20 +35,53 @@
           "https://www.wikidata.org/wiki/Q140010747",
           "https://www.crunchbase.com/organization/prosponsive"
         ]
+      },
+      {
+        "@type": "WebPage",
+        "@id": "https://prosponsive.ai/#webpage",
+        "url": "https://prosponsive.ai/",
+        "name": "Prosponsive — AI That Works While You Don't",
+        "description": "Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine.",
+        "isPartOf": { "@id": "https://prosponsive.ai/#organization" },
+        "about": { "@id": "https://prosponsive.ai/#organization" }
       }
     ]
   }
   </script>
 </head>
 <body>
-  <main>
+
+  <!-- ====================================================
+       Site Header
+  ==================================================== -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="/for/power-users/">For Developers</a>
+        <a href="/for/consultants/">For Consultants</a>
+        <a href="/for/privacy/">For Privacy</a>
+        <a href="/how-it-works/">How It Works</a>
+        <a href="guides/user-guide.html">Guides</a>
+        <a href="#download" class="nav-cta">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- ====================================================
+         Block 1 — Hero
+    ==================================================== -->
     <section class="hero" aria-labelledby="app-name">
       <h1 id="app-name" class="wordmark-heading">
         <img src="assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
       </h1>
-      <p class="tagline">Personal Autonomous Agent Platform</p>
+      <p class="tagline">AI That Works While You Don't</p>
 
-      <div class="download-area">
+      <div class="download-area" id="download">
         <a
           id="download-btn"
           class="btn-download"
@@ -71,6 +104,7 @@
         "If Slack was rebuilt autonomous agent first."
       </p>
       <nav class="hero-nav" aria-label="Quick links">
+        <a href="/how-it-works/">How It Works</a>
         <a href="guides/user-guide.html">Guides</a>
         <a href="releases/">Release Notes</a>
         <a href="guides/feedback.html">Feedback</a>
@@ -78,25 +112,341 @@
       </nav>
     </section>
 
-    <section class="requirements" aria-labelledby="requirements-heading">
-      <h2 id="requirements-heading">System Requirements</h2>
-      <ul>
-        <li><strong>macOS</strong> 12 (Monterey) or later — Apple Silicon (arm64)</li>
-        <li><strong>Windows</strong> 10 or later — x64 or ARM64</li>
-      </ul>
+    <!-- ====================================================
+         Block 2 — Reframe Strip
+    ==================================================== -->
+    <section class="reframe-strip" aria-labelledby="reframe-heading">
+      <div class="section-inner">
+        <h2 id="reframe-heading" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">The AI productivity problem</h2>
+        <p>Everyone knows AI assistants can save time. But most knowledge workers are still switching between five different AI tabs, babysitting every task, and watching their screen while tools "think." We built Prosponsive so your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. It's what Slack would look like if it were built agent-first.</p>
+      </div>
     </section>
+
+    <!-- ====================================================
+         Block 3 — Stat Bar
+    ==================================================== -->
+    <section class="stat-bar" aria-labelledby="stats-heading">
+      <div class="section-inner">
+        <h2 id="stats-heading" style="position:absolute;width:1px;height:1px;overflow:hidden;clip:rect(0,0,0,0)">Key metrics</h2>
+        <div class="stat-grid" role="list">
+          <div class="stat-item" role="listitem">
+            <span class="stat-value">30–90 Min</span>
+            <span class="stat-label">Reclaimed daily from task babysitting</span>
+          </div>
+          <div class="stat-item" role="listitem">
+            <span class="stat-value">2,533</span>
+            <span class="stat-label">Tools across 216 products</span>
+          </div>
+          <div class="stat-item" role="listitem">
+            <span class="stat-value">7+</span>
+            <span class="stat-label">AI providers — switch anytime</span>
+          </div>
+          <div class="stat-item" role="listitem">
+            <span class="stat-value">100%</span>
+            <span class="stat-label">Local execution — data never leaves your machine</span>
+          </div>
+          <div class="stat-item" role="listitem">
+            <span class="stat-value">50–100+</span>
+            <span class="stat-label">Daily interruptions eliminated via auto-approvals</span>
+          </div>
+        </div>
+        <p style="font-size:0.8125rem;color:var(--text-secondary);text-align:center;margin-top:1rem;">Directional estimates — validate before customer-facing ROI use.</p>
+      </div>
+    </section>
+
+    <!-- ====================================================
+         Block 4 — Pillar 01: Reclaim your time
+    ==================================================== -->
+    <section class="pillar-section" aria-labelledby="pillar01-heading">
+      <div class="section-inner">
+        <div class="pillar-header">
+          <span class="pillar-number" aria-hidden="true">01</span>
+          <h2 id="pillar01-heading">Reclaim time from the coordination layer</h2>
+        </div>
+        <div class="pillar-body">
+          <p>Async tools, parallel agents, auto-approvals, and scheduled prompts eliminate task babysitting. Post a task and walk away. Results are waiting when you return.</p>
+          <p>Most AI tools are synchronous — you wait, one step at a time. Prosponsive runs multiple specialized agents in parallel channels, executing tools in the background while you focus on work that matters.</p>
+          <div class="pillar-metrics" aria-label="Pillar 01 metrics">
+            <span class="pillar-metric"><strong>30–90 min/day</strong> reclaimed from task babysitting</span>
+            <span class="pillar-metric"><strong>50–100+</strong> daily interruptions eliminated via auto-approvals</span>
+            <span class="pillar-metric"><strong>3–7 hrs/week</strong> on recurring tasks eliminated by scheduled prompts</span>
+          </div>
+          <div class="pillar-cta">
+            <a href="/how-it-works/" class="btn-secondary">See how it works</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ====================================================
+         Block 5 — Pillar 02: Protect your data & continuity
+    ==================================================== -->
+    <section class="pillar-section" aria-labelledby="pillar02-heading">
+      <div class="section-inner">
+        <div class="pillar-header">
+          <span class="pillar-number" aria-hidden="true">02</span>
+          <h2 id="pillar02-heading">Protect your data, credentials &amp; continuity</h2>
+        </div>
+        <div class="pillar-body">
+          <p>Local execution, credential isolation, automatic failover across 7+ providers, offline-capable. Your data never leaves your machine. Your secrets never touch an AI provider.</p>
+          <p>Sensitive work doesn't have to route through cloud servers. Prosponsive runs on your desktop — your documents, credentials, and workflows stay with you. And if one model goes down, it automatically fails over to the next.</p>
+          <div class="pillar-metrics" aria-label="Pillar 02 metrics">
+            <span class="pillar-metric"><strong>100%</strong> local execution — data sovereignty by design</span>
+            <span class="pillar-metric"><strong>Zero</strong> credential exposure to AI providers</span>
+            <span class="pillar-metric"><strong>0</strong> downtime from single-provider outages via automatic failover</span>
+          </div>
+          <div class="pillar-cta">
+            <a href="guides/security-architecture-whitepaper.html" class="btn-secondary">Read security architecture</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ====================================================
+         Block 6 — Pillar 03: Real tool integration
+    ==================================================== -->
+    <section class="pillar-section" aria-labelledby="pillar03-heading">
+      <div class="section-inner">
+        <div class="pillar-header">
+          <span class="pillar-number" aria-hidden="true">03</span>
+          <h2 id="pillar03-heading">Deploy real tool integration — not just conversation</h2>
+        </div>
+        <div class="pillar-body">
+          <p>n8n workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products — one agent call executes a complete workflow: read a ticket, look up the customer, check billing, and draft the response as a single operation.</p>
+          <p>Not trigger-action automation. Not single MCP calls. Prosponsive agents use n8n-powered tools that coordinate across your real systems — email, CRM, databases, Slack — in one step, with 60–80% fewer tool calls compared to equivalent MCP stacks.</p>
+          <div class="pillar-metrics" aria-label="Pillar 03 metrics">
+            <span class="pillar-metric"><strong>2,533 tools</strong> across 216 products</span>
+            <span class="pillar-metric"><strong>60–80%</strong> fewer tool calls vs. MCP</span>
+            <span class="pillar-metric"><strong>5–10×</strong> faster than custom API development</span>
+          </div>
+          <div class="pillar-cta">
+            <a href="guides/n8n-tool-building-guide.html" class="btn-secondary">Browse integrations</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ====================================================
+         Block 7 — How It Works (mini)
+    ==================================================== -->
+    <section class="how-it-works-mini" aria-labelledby="hiw-heading">
+      <div class="section-inner">
+        <h2 id="hiw-heading" class="section-heading" style="text-align:center;">How it works</h2>
+        <p class="section-subheading" style="text-align:center;margin:0 auto 0;">The bottleneck isn't the AI model. It's the architecture around it.</p>
+        <div class="hiw-steps">
+          <div class="hiw-step">
+            <div class="hiw-step-number" aria-hidden="true">1</div>
+            <h3>Post a task</h3>
+            <p>Drop your request into a channel. Assign it to one or more specialized agents.</p>
+          </div>
+          <div class="hiw-step">
+            <div class="hiw-step-number" aria-hidden="true">2</div>
+            <h3>Agents work in parallel</h3>
+            <p>Multiple agents run simultaneously in channels — your coordination layer.</p>
+          </div>
+          <div class="hiw-step">
+            <div class="hiw-step-number" aria-hidden="true">3</div>
+            <h3>Tools execute async</h3>
+            <p>Workflows connect your real systems — email, CRM, databases — in the background.</p>
+          </div>
+          <div class="hiw-step">
+            <div class="hiw-step-number" aria-hidden="true">4</div>
+            <h3>Results are waiting</h3>
+            <p>Come back to completed work. No babysitting. No approvals per step.</p>
+          </div>
+        </div>
+        <div class="hiw-link">
+          <a href="/how-it-works/" class="btn-secondary">See the full picture</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ====================================================
+         Block 8 — Persona Selector
+    ==================================================== -->
+    <section class="persona-selector" aria-labelledby="personas-heading">
+      <div class="section-inner">
+        <h2 id="personas-heading" class="section-heading">Built for your workflow</h2>
+        <p class="section-subheading">Find your fit — each path leads to what matters most for how you work.</p>
+        <div class="persona-grid">
+          <a href="/for/power-users/" class="persona-card">
+            <div class="persona-card-tier">Developer / Power User</div>
+            <h3>Close the orchestration gap</h3>
+            <p>Your AI stack still has you as the orchestrator. Parallel agents, async tools, credential isolation, and automatic failover — built for people who know what they want from AI.</p>
+            <span class="persona-card-arrow">For developers and power users &rarr;</span>
+          </a>
+          <a href="/for/consultants/" class="persona-card">
+            <div class="persona-card-tier">Independent Professional</div>
+            <h3>Set up once. Walk away.</h3>
+            <p>You shouldn't have to manage your AI. Turn recurring tasks into automatic outcomes — briefings, digests, monitoring — with your data staying on your machine.</p>
+            <span class="persona-card-arrow">For consultants and freelancers &rarr;</span>
+          </a>
+          <a href="/for/privacy/" class="persona-card">
+            <div class="persona-card-tier">Privacy-Conscious Professional</div>
+            <h3>Data sovereignty by design</h3>
+            <p>Sensitive work doesn't have to route through cloud servers. Your documents, credentials, and workflows stay with you — not with a provider.</p>
+            <span class="persona-card-arrow">For legal, finance, HR, and healthcare &rarr;</span>
+          </a>
+          <a href="/for/teams/" class="persona-card">
+            <div class="persona-card-tier">IT / Security Decision Maker</div>
+            <h3>Every AI action auditable</h3>
+            <p>Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.</p>
+            <span class="persona-card-arrow">For IT and security leaders &rarr;</span>
+          </a>
+          <a href="/how-it-works/" class="persona-card">
+            <div class="persona-card-tier">Curious Professional</div>
+            <h3>A team of specialists in a group chat</h3>
+            <p>AI should work while you don't. Drop a task and come back to results, not process. No code. No babysitting. Just outcomes.</p>
+            <span class="persona-card-arrow">See how Prosponsive works &rarr;</span>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <!-- ====================================================
+         Block 9 — Social Proof
+    ==================================================== -->
+    <section class="social-proof" aria-labelledby="proof-heading">
+      <div class="section-inner">
+        <h2 id="proof-heading" class="section-heading">What early adopters are saying</h2>
+        <div class="quote-grid">
+          <div class="quote-block">
+            <blockquote>
+              "I was already running Claude with a stack of MCP servers. I thought I had figured out AI automation — until I realized I was still sitting at my desk approving every tool call, copying context between conversations, and manually sequencing the steps. Prosponsive was the first platform where the agents actually worked without me."
+            </blockquote>
+            <cite>— Early adopter &middot; Software engineer &middot; Independent power user</cite>
+          </div>
+          <div class="quote-block">
+            <blockquote>
+              "The thing that sold me wasn't the feature list — it was the first time I set up a scheduled prompt, walked away, and came back to a completed research brief. I hadn't clicked anything. I hadn't approved anything. It just ran. That's a different category of tool."
+            </blockquote>
+            <cite>— Early adopter &middot; Independent consultant &middot; Prosponsive beta user</cite>
+          </div>
+        </div>
+
+        <div class="outcome-table-wrap">
+          <h3 style="font-size:1.125rem;font-weight:700;color:var(--text-primary);margin-bottom:1rem;">Results by user type</h3>
+          <p style="font-size:0.875rem;color:var(--text-secondary);margin-bottom:1rem;">Directional estimates based on observed usage patterns — validate before customer-facing ROI use.</p>
+          <table class="outcome-table">
+            <thead>
+              <tr>
+                <th>User type</th>
+                <th>Outcome pattern</th>
+                <th>Architecture driver</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Power User / Developer</td>
+                <td>Recovered 60–90 min/day from task babysitting</td>
+                <td>Async tool execution + parallel agent channels</td>
+              </tr>
+              <tr>
+                <td>Independent Consultant</td>
+                <td>Recurring task setup eliminated (briefings, digests, monitoring run automatically)</td>
+                <td>Scheduled prompts + auto-approvals</td>
+              </tr>
+              <tr>
+                <td>Privacy-Conscious Professional</td>
+                <td>Moved sensitive workflows fully local, kept cloud providers for non-sensitive work</td>
+                <td>Local-first + credential isolation</td>
+              </tr>
+              <tr>
+                <td>Multi-Tool Power User</td>
+                <td>Consolidated 4 AI subscriptions into one platform</td>
+                <td>Provider-agnostic + channel scoping</td>
+              </tr>
+              <tr>
+                <td>Operations Manager</td>
+                <td>~70% per-task tool-call overhead reduction on multi-system workflows</td>
+                <td>n8n workflow tools + single-call orchestration</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <!-- ====================================================
+         Block 10 — Competitive Teaser
+    ==================================================== -->
+    <section class="competitive-teaser" aria-labelledby="compare-heading">
+      <div class="section-inner">
+        <h2 id="compare-heading">Already using Claude, GPT, or Zapier?</h2>
+        <p>Prosponsive is not a replacement for your AI subscriptions — it's the coordination layer that makes them work together, locally, in parallel. See how the architectures compare.</p>
+        <a href="guides/compare/" class="btn-secondary">Compare Prosponsive to alternatives</a>
+      </div>
+    </section>
+
+    <!-- ====================================================
+         Block 11 — Final CTA Band
+    ==================================================== -->
+    <section class="cta-band" aria-labelledby="cta-heading">
+      <div class="section-inner">
+        <h2 id="cta-heading">AI That Works While You Don't</h2>
+        <p>Prosponsive is the personal autonomous agent platform that runs AI assistants locally on your desktop — so your agents actually work while you don't.</p>
+
+        <div class="download-area">
+          <a
+            id="download-btn-footer"
+            class="btn-download"
+            href="#"
+            aria-label="Download Prosponsive for macOS"
+          >
+            Download for macOS
+          </a>
+        </div>
+        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
+
+        <section class="requirements" aria-labelledby="req-heading">
+          <h2 id="req-heading">System Requirements</h2>
+          <ul>
+            <li><strong>macOS</strong> 12 (Monterey) or later — Apple Silicon (arm64)</li>
+            <li><strong>Windows</strong> 10 or later — x64 or ARM64</li>
+          </ul>
+        </section>
+      </div>
+    </section>
+
   </main>
 
+  <!-- ====================================================
+       Footer
+  ==================================================== -->
   <footer>
     <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
-    <nav aria-label="Footer links">
+    <nav class="footer-nav-extended" aria-label="Footer links">
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
       <a href="guides/user-guide.html">Guides</a>
       <a href="releases/">Release Notes</a>
+      <a href="guides/compare/">Compare</a>
       <a href="guides/feedback.html">Feedback</a>
       <a href="/legal/">Legal</a>
     </nav>
   </footer>
 
   <script src="js/download.js"></script>
+  <script>
+    // Mirror the download button state to the footer CTA button
+    (function () {
+      function syncFooterBtn() {
+        var primaryBtn = document.getElementById('download-btn');
+        var footerBtn = document.getElementById('download-btn-footer');
+        if (!primaryBtn || !footerBtn) return;
+        footerBtn.href = primaryBtn.href;
+        footerBtn.textContent = primaryBtn.textContent;
+        footerBtn.setAttribute('aria-label', primaryBtn.getAttribute('aria-label') || primaryBtn.textContent);
+      }
+      // Sync after download.js runs (it fires on DOMContentLoaded + after fetch)
+      document.addEventListener('DOMContentLoaded', function () {
+        setTimeout(syncFooterBtn, 100);
+        setTimeout(syncFooterBtn, 2000);
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/security/index.html
+++ b/security/index.html
@@ -1,0 +1,271 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Security Architecture — Prosponsive</title>
+  <meta name="description" content="Prosponsive's security model: local execution, credential isolation, tool runtime containment, and no server-side data storage.">
+  <link rel="canonical" href="https://prosponsive.ai/security/">
+  <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
+  <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
+  <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://prosponsive.ai/security/#webpage",
+    "url": "https://prosponsive.ai/security/",
+    "name": "Security Architecture — Prosponsive",
+    "description": "Prosponsive's security model: local execution, credential isolation, tool runtime containment, and no server-side data storage.",
+    "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
+  }
+  </script>
+</head>
+<body class="page-wrapper">
+
+  <!-- Site Header -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="/for/power-users/">For Developers</a>
+        <a href="/for/consultants/">For Consultants</a>
+        <a href="/for/privacy/">For Privacy</a>
+        <a href="/for/teams/">For Teams</a>
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../guides/user-guide.html">Guides</a>
+        <a href="/#download" class="nav-cta">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb section-inner" style="padding-top:1rem;padding-bottom:1rem;">
+      <a href="/">Home</a><span aria-hidden="true"> › </span>Security Architecture
+    </div>
+
+    <!-- Hero -->
+    <section class="persona-hero" aria-labelledby="hero-heading">
+      <div class="section-inner">
+        <h1 id="hero-heading">Security by architecture, not policy.</h1>
+        <p class="persona-hero-message">Local execution. Isolated tool runtime. Zero server-side data storage. Here's how it works.</p>
+        <div class="persona-hero-cta">
+          <a href="/download/" class="btn-secondary">Download free</a>
+        </div>
+      </div>
+    </section>
+
+    <!-- Section 1: Architecture overview -->
+    <section aria-labelledby="arch-heading">
+      <div class="section-inner">
+        <h2 id="arch-heading" class="section-heading">The trust boundary</h2>
+        <p class="section-subheading">Prosponsive is structured as a layered model where each tier communicates only with the tier directly adjacent to it. Credentials never cross a tier boundary.</p>
+
+        <div class="arch-diagram" role="img" aria-label="Architecture diagram showing four tiers: LLM Provider (remote), Agent Runtime (local), Tool Runtime n8n container, and Your Systems, plus a separate Credential Store accessible only to the Tool Runtime">
+
+          <div class="arch-tier arch-tier--remote">
+            <span class="arch-tier-label">Remote</span>
+            <div class="arch-tier-box">
+              <strong>LLM Provider</strong>
+              <span class="arch-tier-note">e.g. Anthropic, OpenAI, Ollama</span>
+            </div>
+          </div>
+
+          <div class="arch-connector" aria-hidden="true">
+            <span class="arch-connector-arrow">&#x21D5;</span>
+            <span class="arch-connector-desc">inference calls (prompt + context only)</span>
+          </div>
+
+          <div class="arch-tier arch-tier--local">
+            <span class="arch-tier-label">Local</span>
+            <div class="arch-tier-box">
+              <strong>Agent Runtime</strong>
+              <span class="arch-tier-note">Prosponsive desktop app</span>
+            </div>
+          </div>
+
+          <div class="arch-connector" aria-hidden="true">
+            <span class="arch-connector-arrow">&#x21D5;</span>
+            <span class="arch-connector-desc">tool requests / results only</span>
+          </div>
+
+          <div class="arch-tier arch-tier--local">
+            <span class="arch-tier-label">Local</span>
+            <div class="arch-tier-box arch-tier-box--isolated">
+              <strong>Tool Runtime &mdash; n8n container</strong>
+              <span class="arch-tier-note">isolated container with its own storage</span>
+            </div>
+          </div>
+
+          <div class="arch-connector" aria-hidden="true">
+            <span class="arch-connector-arrow">&#x21D5;</span>
+            <span class="arch-connector-desc">external API calls</span>
+          </div>
+
+          <div class="arch-tier arch-tier--external">
+            <span class="arch-tier-label">External</span>
+            <div class="arch-tier-box">
+              <strong>Your Systems</strong>
+              <span class="arch-tier-note">Salesforce, NetSuite, Slack, etc.</span>
+            </div>
+          </div>
+
+          <div class="arch-credential-store" aria-hidden="true">
+            <div class="arch-credential-box">
+              <strong>Credential Store</strong>
+              <span class="arch-tier-note">accessible only inside Tool Runtime</span>
+            </div>
+          </div>
+
+        </div><!-- /.arch-diagram -->
+
+        <div class="arch-legend" aria-hidden="true">
+          <span class="arch-legend-item arch-legend-remote">Remote</span>
+          <span class="arch-legend-item arch-legend-local">Local</span>
+          <span class="arch-legend-item arch-legend-external">External (your systems)</span>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- Section 2: Security principles -->
+    <section aria-labelledby="principles-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="principles-heading" class="section-heading">Security principles</h2>
+        <p class="section-subheading">Six properties enforced by the architecture, not by configuration or policy.</p>
+
+        <ul class="value-props value-props--grid" role="list">
+          <li class="value-prop-item">
+            <div class="value-prop-content">
+              <h3>Local-first execution</h3>
+              <p>Agent runtime, tool execution, and storage all run on the user's machine. Nothing routes through Prosponsive servers. There is no cloud routing layer for your content.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <div class="value-prop-content">
+              <h3>Least-privilege credential storage</h3>
+              <p>Credentials are encrypted locally. They are accessible only to the tool execution runtime, not to the agent runtime or the LLM. The agent never sees credentials in any form.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <div class="value-prop-content">
+              <h3>Tool runtime isolation</h3>
+              <p>n8n runs in an isolated container with its own storage. The agent sends a request and receives only the result. Credentials and internal container state are never exposed to the agent runtime.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <div class="value-prop-content">
+              <h3>No server-side data storage</h3>
+              <p>Conversation history, documents, and workflow state are never sent to or stored by Prosponsive. Your data exists only on your machine. This is enforced by the architecture, not a setting.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <div class="value-prop-content">
+              <h3>Encrypted at rest</h3>
+              <p>All local data is encrypted. Credentials are stored with least-privilege access — the agent runtime and LLM cannot access the credential store directly under any code path.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <div class="value-prop-content">
+              <h3>Provider-agnostic design</h3>
+              <p>No vendor lock-in on the security model. Swap AI providers without re-architecting. Automatic failover between providers does not change the isolation model or credential boundaries.</p>
+            </div>
+          </li>
+        </ul>
+
+      </div>
+    </section>
+
+    <!-- Section 3: Data flow table -->
+    <section aria-labelledby="dataflow-heading">
+      <div class="section-inner">
+        <h2 id="dataflow-heading" class="section-heading">What leaves your machine</h2>
+        <p class="section-subheading" style="margin-bottom:1.5rem;">The short answer: very little, and never anything sensitive.</p>
+
+        <div class="outcome-table-wrap">
+          <table class="outcome-table">
+            <thead>
+              <tr>
+                <th>Data</th>
+                <th>Destination</th>
+                <th>Notes</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>LLM inference calls</td>
+                <td>Configured AI provider</td>
+                <td>Prompt + context only. Credentials are never included in inference calls.</td>
+              </tr>
+              <tr>
+                <td>Tool call results</td>
+                <td>Returned to agent runtime (local)</td>
+                <td>Results only. No credentials or internal container state are passed back.</td>
+              </tr>
+              <tr>
+                <td>Update checks</td>
+                <td>Prosponsive update server</td>
+                <td>Version string only. No usage data, identifiers, or content.</td>
+              </tr>
+              <tr>
+                <td>Everything else</td>
+                <td>Stays on your machine</td>
+                <td>Conversation history, documents, credentials, workflow state — never transmitted.</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <p style="margin-top:1.25rem;font-size:0.9375rem;color:var(--text-secondary);max-width:680px;">The tool runtime is a black box to the agent runtime &mdash; it receives requests and returns results. Credentials never leave the container.</p>
+
+      </div>
+    </section>
+
+    <!-- Section 4: Implementation details -->
+    <section aria-labelledby="impl-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
+      <div class="section-inner">
+        <h2 id="impl-heading" class="section-heading">Implementation details</h2>
+        <p class="section-subheading">For security engineers doing technical due diligence.</p>
+
+        <div class="hiw-narrative" style="margin-top:2rem;">
+          <p><strong>Credential injection model.</strong> Credentials are stored inside the n8n container and are never passed to or visible by the agent runtime or the LLM. When the agent calls a tool by name, the request travels to the tool runtime. The container resolves which credential that tool requires and injects it internally. The credential does not appear in the request from the agent, and does not appear in the result returned to the agent. There is no code path where the agent runtime handles a plaintext credential.</p>
+
+          <p><strong>Blast radius control.</strong> Auto-approval rules define exactly what agents can do without human confirmation &mdash; scoped by tool set, action type, or channel. Actions outside the approved rules require explicit human review before execution. This limits the blast radius of a misconfigured or misbehaving agent to the scope the operator has explicitly permitted.</p>
+
+          <p><strong>No Prosponsive account required.</strong> Prosponsive does not require account creation to use the product. No user identity data is sent to Prosponsive servers. The only optional network communication is version check requests, which transmit a version string with no user-identifying information attached.</p>
+        </div>
+
+      </div>
+    </section>
+
+    <!-- CTA Band -->
+    <section class="cta-band" aria-labelledby="cta-heading">
+      <div class="section-inner">
+        <h2 id="cta-heading">Built for sensitive work.</h2>
+        <p>Download Prosponsive and see the security model in action. Local execution. Free.</p>
+        <a href="/download/" class="btn-download">Download free</a>
+      </div>
+    </section>
+
+  </main>
+
+  <footer>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../guides/user-guide.html">Guides</a>
+        <a href="../guides/compare/">Compare</a>
+        <a href="../releases/">Release Notes</a>
+        <a href="/legal/">Legal</a>
+      </nav>
+    </div>
+  </footer>
+
+</body>
+</html>

--- a/security/index.html
+++ b/security/index.html
@@ -4,12 +4,24 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Security Architecture — Prosponsive</title>
-  <meta name="description" content="Prosponsive's security model: local execution, credential isolation, tool runtime containment, and no server-side data storage.">
+  <meta name="description" content="Prosponsive's security model: local execution, credential isolation, tool runtime containment, no server-side storage, and permanent hard-delete for local data.">
   <link rel="canonical" href="https://prosponsive.ai/security/">
+  <meta property="og:title" content="Security Architecture — Prosponsive">
+  <meta property="og:description" content="Prosponsive's security model: local execution, credential isolation, tool runtime containment, no server-side storage, and permanent hard-delete for local data.">
+  <meta property="og:url" content="https://prosponsive.ai/security/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Security Architecture — Prosponsive">
+  <meta name="twitter:description" content="Prosponsive's security model: local execution, credential isolation, tool runtime containment, no server-side storage, and permanent hard-delete for local data.">
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../css/styles.css">
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -64,71 +76,47 @@
     <section aria-labelledby="arch-heading">
       <div class="section-inner">
         <h2 id="arch-heading" class="section-heading">The trust boundary</h2>
-        <p class="section-subheading">Prosponsive is structured as a layered model where each tier communicates only with the tier directly adjacent to it. Credentials never cross a tier boundary.</p>
+        <p style="font-size:0.9375rem;color:var(--text-secondary);line-height:1.65;margin-bottom:0.875rem;">Prosponsive is structured as a layered model using containers for runtime isolation and separate storage for access separation. Each tier communicates only with the tier directly adjacent to it. Credentials never cross a tier boundary.</p>
 
-        <div class="arch-diagram" role="img" aria-label="Architecture diagram showing four tiers: LLM Provider (remote), Agent Runtime (local), Tool Runtime n8n container, and Your Systems, plus a separate Credential Store accessible only to the Tool Runtime">
+        <p style="font-size:0.9375rem;color:var(--text-secondary);line-height:1.65;margin-bottom:1.5rem;">The diagram below shows all components running on localhost only. The Electron app (UI and main process API) communicates with the <a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> tool runtime and PostgreSQL over TLS. n8n and PostgreSQL run in an isolated private container network — not reachable from the host network or LAN. Each database is accessible only by its own dedicated user; no cross-database access is permitted.</p>
 
-          <div class="arch-tier arch-tier--remote">
-            <span class="arch-tier-label">Remote</span>
-            <div class="arch-tier-box">
-              <strong>LLM Provider</strong>
-              <span class="arch-tier-note">e.g. Anthropic, OpenAI, Ollama</span>
-            </div>
-          </div>
+        <div class="mermaid">
+graph LR
+    subgraph machine["Localhost Only"]
 
-          <div class="arch-connector" aria-hidden="true">
-            <span class="arch-connector-arrow">&#x21D5;</span>
-            <span class="arch-connector-desc">inference calls (prompt + context only)</span>
-          </div>
+        subgraph electron["Electron Application (host)"]
+            api["Main Process<br/>HTTPS API :3100"]
+            renderer["Renderer (UI)"]
+            api --- renderer
+        end
 
-          <div class="arch-tier arch-tier--local">
-            <span class="arch-tier-label">Local</span>
-            <div class="arch-tier-box">
-              <strong>Agent Runtime</strong>
-              <span class="arch-tier-note">Prosponsive desktop app</span>
-            </div>
-          </div>
+        subgraph containerNet["Private Network"]
 
-          <div class="arch-connector" aria-hidden="true">
-            <span class="arch-connector-arrow">&#x21D5;</span>
-            <span class="arch-connector-desc">tool requests / results only</span>
-          </div>
+            n8n["n8n Container<br/>:5678"]
 
-          <div class="arch-tier arch-tier--local">
-            <span class="arch-tier-label">Local</span>
-            <div class="arch-tier-box arch-tier-box--isolated">
-              <strong>Tool Runtime &mdash; n8n container</strong>
-              <span class="arch-tier-note">isolated container with its own storage</span>
-            </div>
-          </div>
+            subgraph pgcontainer["PostgreSQL Container :5432"]
+                n8ndb["n8n db<br/>user: n8n<br/>workflows, executions,<br/>credentials"]
+                prospdb["prosponsive db<br/>user: prosponsive<br/>conversations, messages,<br/>tasks"]
+            end
+        end
 
-          <div class="arch-connector" aria-hidden="true">
-            <span class="arch-connector-arrow">&#x21D5;</span>
-            <span class="arch-connector-desc">external API calls</span>
-          </div>
+        api -- "TLS / SCRAM-SHA-256<br/>via mapped port" --> prospdb
+        renderer -- "TLS" --> n8n
+        n8n -. "SCRAM-SHA-256<br/>container-internal" .-> n8ndb
+        n8n -- "TLS webhooks<br/>via host gateway" --> api
+    end
 
-          <div class="arch-tier arch-tier--external">
-            <span class="arch-tier-label">External</span>
-            <div class="arch-tier-box">
-              <strong>Your Systems</strong>
-              <span class="arch-tier-note">Salesforce, NetSuite, Slack, etc.</span>
-            </div>
-          </div>
-
-          <div class="arch-credential-store" aria-hidden="true">
-            <div class="arch-credential-box">
-              <strong>Credential Store</strong>
-              <span class="arch-tier-note">accessible only inside Tool Runtime</span>
-            </div>
-          </div>
-
-        </div><!-- /.arch-diagram -->
-
-        <div class="arch-legend" aria-hidden="true">
-          <span class="arch-legend-item arch-legend-remote">Remote</span>
-          <span class="arch-legend-item arch-legend-local">Local</span>
-          <span class="arch-legend-item arch-legend-external">External (your systems)</span>
+    style machine fill:none,stroke:#666,stroke-width:2px
+    style electron fill:none,stroke:#4a9eff,stroke-width:2px
+    style containerNet fill:none,stroke:#f59e0b,stroke-width:2px,stroke-dasharray:8
+    style pgcontainer fill:none,stroke:#22c55e,stroke-width:2px
+    style n8ndb fill:none,stroke:#22c55e,stroke-width:1px,stroke-dasharray:5
+    style prospdb fill:none,stroke:#22c55e,stroke-width:1px,stroke-dasharray:5
         </div>
+
+        <p style="font-size:0.875rem;color:var(--text-secondary);line-height:1.65;margin-top:1rem;border-left:3px solid var(--border);padding-left:1rem;"><strong>LLM inference (not shown):</strong> The main process makes outbound inference calls to either Ollama running locally on the machine, or to an external LLM provider (Anthropic, OpenAI, etc.) over HTTPS. Only the prompt and context are sent — credentials and data never leave the machine as part of inference calls.</p>
+
+        <p style="font-size:0.875rem;color:var(--text-secondary);line-height:1.65;margin-top:0.75rem;border-left:3px solid var(--border);padding-left:1rem;"><strong>n8n tool calls (not shown):</strong> Tools you build in n8n can make any outbound call their workflow is configured to make — reading from or writing to Salesforce, querying a database, calling a REST API, sending a webhook. You design the tool; you decide what it touches. Prosponsive does not restrict or inspect what your tools call, and never initiates any external call on its own.</p>
 
       </div>
     </section>
@@ -137,7 +125,7 @@
     <section aria-labelledby="principles-heading" style="background-color:var(--surface);border-top:1px solid var(--border);">
       <div class="section-inner">
         <h2 id="principles-heading" class="section-heading">Security principles</h2>
-        <p class="section-subheading">Six properties enforced by the architecture, not by configuration or policy.</p>
+        <p class="section-subheading">Properties enforced by the architecture, not by configuration or policy.</p>
 
         <ul class="value-props value-props--grid" role="list">
           <li class="value-prop-item">
@@ -148,14 +136,14 @@
           </li>
           <li class="value-prop-item">
             <div class="value-prop-content">
-              <h3>Least-privilege credential storage</h3>
-              <p>Credentials are encrypted locally. They are accessible only to the tool execution runtime, not to the agent runtime or the LLM. The agent never sees credentials in any form.</p>
+              <h3>Least-privilege access</h3>
+              <p>Every resource Prosponsive touches — credentials, database connections, files — is granted the minimum access required. Credentials are accessible only to the tool execution runtime. Database users can only access their own database. Files are created with 0600/0700 permissions. The agent runtime and LLM cannot access the credential store under any code path.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <div class="value-prop-content">
               <h3>Tool runtime isolation</h3>
-              <p>n8n runs in an isolated container with its own storage. The agent sends a request and receives only the result. Credentials and internal container state are never exposed to the agent runtime.</p>
+              <p>Tools run in <a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> as an isolated container with its own storage. The agent sends a request and receives only the result. Credentials and internal container state are never exposed to the agent runtime. Because tools execute inside a container, they have no access to the host OS filesystem or host processes — the container boundary prevents any tool from reading arbitrary files or interacting with the host system directly. Tools can make outbound network calls to external systems and communicate back to the Prosponsive API via defined channels, but nothing beyond those explicitly permitted paths.</p>
             </div>
           </li>
           <li class="value-prop-item">
@@ -166,14 +154,26 @@
           </li>
           <li class="value-prop-item">
             <div class="value-prop-content">
-              <h3>Encrypted at rest</h3>
-              <p>All local data is encrypted. Credentials are stored with least-privilege access — the agent runtime and LLM cannot access the credential store directly under any code path.</p>
+              <h3>FIPS encryption in transit and at rest</h3>
+              <p>All local data is encrypted at rest using AES-256-GCM. All communication between components — including localhost-only traffic — is SSL-enforced. Even though all traffic stays on the machine, TLS is required on every connection: the renderer to n8n, the main process to PostgreSQL, and the n8n container back to the host API.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <div class="value-prop-content">
+              <h3>Data retention — built-in, not bolted on</h3>
+              <p>Prosponsive enforces data retention by design. Soft delete marks data as deleted and excludes it from all views immediately. Hard delete permanently and irreversibly purges your local data — there is no server-side copy to recover from, so a hard delete is truly final. Inactive conversations are automatically archived after a configurable period (default: 60 days) and enter the same hard-delete lifecycle.</p>
             </div>
           </li>
           <li class="value-prop-item">
             <div class="value-prop-content">
               <h3>Provider-agnostic design</h3>
               <p>No vendor lock-in on the security model. Swap AI providers without re-architecting. Automatic failover between providers does not change the isolation model or credential boundaries.</p>
+            </div>
+          </li>
+          <li class="value-prop-item">
+            <div class="value-prop-content">
+              <h3>Supply chain security</h3>
+              <p>Security is enforced at two layers. Every pull request runs dependency vulnerability scanning, static analysis (SAST), and secret scanning before code can merge. In parallel, the repository is continuously and proactively scanned — newly disclosed vulnerabilities in dependencies, container images, and the runtime stack trigger P1 priorities and often automated remediation processes that close them within the same release cycle, independent of any scheduled update window. Dependencies are locked with cryptographic integrity hashes. Container images are pinned by SHA-256 manifest digest.</p>
             </div>
           </li>
         </ul>
@@ -203,19 +203,24 @@
                 <td>Prompt + context only. Credentials are never included in inference calls.</td>
               </tr>
               <tr>
-                <td>Tool call results</td>
-                <td>Returned to agent runtime (local)</td>
-                <td>Results only. No credentials or internal container state are passed back.</td>
-              </tr>
-              <tr>
-                <td>Update checks</td>
+                <td>Version checks</td>
                 <td>Prosponsive update server</td>
-                <td>Version string only. No usage data, identifiers, or content.</td>
+                <td>Current version string only. No usage data, user identifiers, or content of any kind.</td>
               </tr>
               <tr>
-                <td>Everything else</td>
-                <td>Stays on your machine</td>
-                <td>Conversation history, documents, credentials, workflow state — never transmitted.</td>
+                <td>Subscription validation &amp; usage volume</td>
+                <td>Prosponsive billing server</td>
+                <td>An anonymous subscriber identifier and usage volume (e.g. number of agent runs). No tool names, prompt content, conversation data, or any user-generated content is included.</td>
+              </tr>
+              <tr>
+                <td>Instrumentation &amp; observability data <em>(optional)</em></td>
+                <td>Prosponsive diagnostics server</td>
+                <td>Opt-in only. If enabled, sends anonymized crash reports and performance diagnostics to help improve the product. Never includes conversation content, tool names, credentials, or any user-generated data. Disabled by default.</td>
+              </tr>
+              <tr>
+                <td>Tool calls to external systems</td>
+                <td>Your discretion — whatever your tools are configured to call</td>
+                <td>Prosponsive never initiates external calls on its own. Every outbound call is the result of a tool you configured. You own the tool design; you decide what gets called.</td>
               </tr>
             </tbody>
           </table>
@@ -235,9 +240,11 @@
         <div class="hiw-narrative" style="margin-top:2rem;">
           <p><strong>Credential injection model.</strong> Credentials are stored inside the n8n container and are never passed to or visible by the agent runtime or the LLM. When the agent calls a tool by name, the request travels to the tool runtime. The container resolves which credential that tool requires and injects it internally. The credential does not appear in the request from the agent, and does not appear in the result returned to the agent. There is no code path where the agent runtime handles a plaintext credential.</p>
 
-          <p><strong>Blast radius control.</strong> Auto-approval rules define exactly what agents can do without human confirmation &mdash; scoped by tool set, action type, or channel. Actions outside the approved rules require explicit human review before execution. This limits the blast radius of a misconfigured or misbehaving agent to the scope the operator has explicitly permitted.</p>
+          <p><strong>Blast radius control.</strong> Auto-approval rules define exactly what agents can do without human confirmation &mdash; scoped by tool set, action type, or channel. Rules can also incorporate LLM confidence thresholds: a high-confidence threshold auto-approves only when the model's confidence in the tool call exceeds it; a low-confidence threshold auto-denies below a floor and stops the action before it's even proposed; everything in between is surfaced for manual review. Actions outside the approved rules require explicit human confirmation before execution. This limits the blast radius of a misconfigured or misbehaving agent to the scope the operator has explicitly permitted.</p>
 
-          <p><strong>No Prosponsive account required.</strong> Prosponsive does not require account creation to use the product. No user identity data is sent to Prosponsive servers. The only optional network communication is version check requests, which transmit a version string with no user-identifying information attached.</p>
+          <p><strong>Full tool execution audit trail.</strong> Every tool use is logged by <a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> with full inputs and outputs. Every workflow execution step is captured and traceable for review at any time — what ran, when, what data went in, and what came back. All of this stays local on your machine. This is a native property of n8n, not something Prosponsive adds on top.</p>
+
+          <p><strong>No Prosponsive account required.</strong> Prosponsive does not require account creation to use the product. No user identity data is sent to Prosponsive servers. Version check requests transmit a version string with no user-identifying information attached.</p>
         </div>
 
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -42,6 +42,12 @@
   </url>
 
   <url>
+    <loc>https://prosponsive.ai/security/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
     <loc>https://prosponsive.ai/guides/user-guide.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,46 +3,54 @@
 
   <url>
     <loc>https://prosponsive.ai/</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://prosponsive.ai/download/</loc>
+    <lastmod>2026-06-03</lastmod>
   </url>
 
   <url>
     <loc>https://prosponsive.ai/how-it-works/</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <url>
     <loc>https://prosponsive.ai/for/power-users/</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://prosponsive.ai/for/consultants/</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://prosponsive.ai/for/privacy/</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://prosponsive.ai/for/teams/</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>
 
   <url>
     <loc>https://prosponsive.ai/security/</loc>
+    <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,6 +8,36 @@
   </url>
 
   <url>
+    <loc>https://prosponsive.ai/how-it-works/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/for/power-users/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/for/consultants/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/for/privacy/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://prosponsive.ai/for/teams/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+
+  <url>
     <loc>https://prosponsive.ai/guides/user-guide.html</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -8,6 +8,10 @@
   </url>
 
   <url>
+    <loc>https://prosponsive.ai/download/</loc>
+  </url>
+
+  <url>
     <loc>https://prosponsive.ai/how-it-works/</loc>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>


### PR DESCRIPTION
## Summary

Implements Phase 1 of the GTM-driven website redesign per the approved spec (`4803fa1`, issue #77/#78): full home page rework plus four `/for/` persona landing pages and a `/how-it-works/` page.

Closes #79

## Changes

- **`index.html`** — full home rework, 12 sections per spec §2.3 (hero → reframe → stat bar → 3 pillars → how-it-works mini → persona selector → social proof → competitive teaser → CTA band → footer)
- **`css/styles.css`** — extended with new component styles (389 → 1321 lines)
- **`for/power-users/index.html`** — new persona page
- **`for/consultants/index.html`** — new persona page
- **`for/privacy/index.html`** — new persona page
- **`for/teams/index.html`** — new persona page
- **`how-it-works/index.html`** — new page
- **`sitemap.xml`** — 5 new URLs added; existing `/guides/compare/*` canonical entries preserved

## Review focus

- Copy fidelity vs spec Appendix B / §1.3 / §1.5 / §1.6 (taglines, persona messages, quotes, stats verbatim)
- Design token consistency (no `#2D6A4F`, `#F8F6F0`, Georgia serif in new files)
- No placeholder copy
- Navigation completeness (persona selector → 4 `/for/` pages; Curious Professional → `/how-it-works/`; footer nav)
- WCAG AA color contrast on key elements
- Spec §2.3 section sequence coverage on home
- Each `/for/` page leads with verbatim persona message (§1.3) and ranked value props (§1.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
