### PR TITLE
fix: route all download buttons to /download/, add Home nav link

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -839,10 +839,15 @@ h1 {
 }
 
 .persona-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 1.125rem;
   margin-bottom: 3.5rem;
+}
+
+.persona-grid .persona-card {
+  flex: 0 0 calc((100% - 2.25rem) / 3);
 }
 
 .persona-card {
@@ -912,14 +917,14 @@ h1 {
 }
 
 @media (max-width: 900px) {
-  .persona-grid {
-    grid-template-columns: repeat(2, 1fr);
+  .persona-grid .persona-card {
+    flex: 0 0 calc((100% - 1.125rem) / 2);
   }
 }
 
 @media (max-width: 767px) {
-  .persona-grid {
-    grid-template-columns: 1fr;
+  .persona-grid .persona-card {
+    flex: 0 0 100%;
   }
   .persona-card:hover,
   .persona-card:focus-visible {

--- a/download/index.html
+++ b/download/index.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Download Prosponsive — macOS &amp; Windows</title>
-  <meta name="description" content="Download Prosponsive free for macOS or Windows. Personal autonomous agent platform — AI agents run tools in the background while you're away, data stays local.">
+  <meta name="description" content="Download Prosponsive free for macOS or Windows. AI That Works While You Don't — agents run tools in the background while you're away, data stays local.">
   <link rel="canonical" href="https://prosponsive.ai/download/">
   <meta property="og:title" content="Download Prosponsive — macOS &amp; Windows">
-  <meta property="og:description" content="Download Prosponsive free for macOS or Windows. Personal autonomous agent platform — AI agents run tools in the background while you're away, data stays local.">
+  <meta property="og:description" content="Download Prosponsive free for macOS or Windows. AI That Works While You Don't — agents run tools in the background while you're away, data stays local.">
   <meta property="og:url" content="https://prosponsive.ai/download/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Download Prosponsive — macOS &amp; Windows">
-  <meta name="twitter:description" content="Download Prosponsive free for macOS or Windows. Personal autonomous agent platform — AI agents run tools in the background while you're away, data stays local.">
+  <meta name="twitter:description" content="Download Prosponsive free for macOS or Windows. AI That Works While You Don't — agents run tools in the background while you're away, data stays local.">
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
@@ -25,7 +25,7 @@
     "@id": "https://prosponsive.ai/download/#webpage",
     "url": "https://prosponsive.ai/download/",
     "name": "Download Prosponsive — macOS &amp; Windows",
-    "description": "Download Prosponsive for macOS or Windows. Your personal autonomous agent platform — AI that works while you don't.",
+    "description": "Download Prosponsive for macOS or Windows. AI That Works While You Don't — agents run in the background, data stays local.",
     "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
   }
   </script>

--- a/for/consultants/index.html
+++ b/for/consultants/index.html
@@ -39,12 +39,13 @@
         <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
       </a>
       <nav class="site-nav" aria-label="Main navigation">
+        <a href="/">Home</a>
         <a href="/for/power-users/">For Developers</a>
         <a href="/for/consultants/" aria-current="page">For Consultants</a>
         <a href="/for/privacy/">For Privacy</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
-        <a href="/#download" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta">Download</a>
       </nav>
     </div>
   </header>
@@ -62,7 +63,7 @@
         <h1 id="hero-heading">Set up once. Assign work. Walk away.</h1>
         <p class="persona-hero-message">You shouldn't have to manage your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.</p>
         <div class="persona-hero-cta">
-          <a href="/#download" class="btn-download">Download for macOS</a>
+          <a href="/download/" class="btn-download">Download for macOS</a>
           <a href="/how-it-works/" class="btn-secondary">See scheduled prompts</a>
         </div>
       </div>
@@ -152,7 +153,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Your recurring work. Automated.</h2>
         <p>Set up once, assign work, walk away. Prosponsive is free to download for macOS and Windows.</p>
-        <a href="/#download" class="btn-download">Download for macOS</a>
+        <a href="/download/" class="btn-download">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>

--- a/for/consultants/index.html
+++ b/for/consultants/index.html
@@ -43,6 +43,7 @@
         <a href="/for/power-users/">For Developers</a>
         <a href="/for/consultants/" aria-current="page">For Consultants</a>
         <a href="/for/privacy/">For Privacy</a>
+        <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
         <a href="/download/" class="nav-cta">Download</a>

--- a/for/power-users/index.html
+++ b/for/power-users/index.html
@@ -43,6 +43,7 @@
         <a href="/for/power-users/" aria-current="page">For Developers</a>
         <a href="/for/consultants/">For Consultants</a>
         <a href="/for/privacy/">For Privacy</a>
+        <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
         <a href="/download/" class="nav-cta">Download</a>

--- a/for/power-users/index.html
+++ b/for/power-users/index.html
@@ -39,12 +39,13 @@
         <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
       </a>
       <nav class="site-nav" aria-label="Main navigation">
+        <a href="/">Home</a>
         <a href="/for/power-users/" aria-current="page">For Developers</a>
         <a href="/for/consultants/">For Consultants</a>
         <a href="/for/privacy/">For Privacy</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
-        <a href="/#download" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta">Download</a>
       </nav>
     </div>
   </header>
@@ -62,7 +63,7 @@
         <h1 id="hero-heading">Your AI stack still has you as the orchestrator.</h1>
         <p class="persona-hero-message">Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover. Built for people who know what they actually want from AI.</p>
         <div class="persona-hero-cta">
-          <a href="/#download" class="btn-download">Download for macOS</a>
+          <a href="/download/" class="btn-download">Download for macOS</a>
           <a href="../../guides/compare/vs-cloud-chat.html" class="btn-secondary">Compare to cloud AI</a>
         </div>
       </div>
@@ -170,7 +171,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Close the orchestration loop.</h2>
         <p>Download Prosponsive and run your first parallel agent workflow in minutes. macOS and Windows, free to download.</p>
-        <a href="/#download" class="btn-download">Download for macOS</a>
+        <a href="/download/" class="btn-download">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>

--- a/for/privacy/index.html
+++ b/for/privacy/index.html
@@ -39,12 +39,13 @@
         <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
       </a>
       <nav class="site-nav" aria-label="Main navigation">
+        <a href="/">Home</a>
         <a href="/for/power-users/">For Developers</a>
         <a href="/for/consultants/">For Consultants</a>
         <a href="/for/privacy/" aria-current="page">For Privacy</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
-        <a href="/#download" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta">Download</a>
       </nav>
     </div>
   </header>
@@ -62,7 +63,7 @@
         <h1 id="hero-heading">Sensitive work doesn't have to route through the cloud.</h1>
         <p class="persona-hero-message">Sensitive work doesn't need cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, never sent to a provider.</p>
         <div class="persona-hero-cta">
-          <a href="/#download" class="btn-download">Download for macOS</a>
+          <a href="/download/" class="btn-download">Download for macOS</a>
           <a href="/security/" class="btn-secondary">Read security architecture</a>
         </div>
       </div>
@@ -167,7 +168,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Your data stays with you.</h2>
         <p>Prosponsive is the personal autonomous agent platform built for sensitive work. Local execution, credential isolation, and local AI model support — by design.</p>
-        <a href="/#download" class="btn-download">Download for macOS</a>
+        <a href="/download/" class="btn-download">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>

--- a/for/teams/index.html
+++ b/for/teams/index.html
@@ -39,13 +39,14 @@
         <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
       </a>
       <nav class="site-nav" aria-label="Main navigation">
+        <a href="/">Home</a>
         <a href="/for/power-users/">For Developers</a>
         <a href="/for/consultants/">For Consultants</a>
         <a href="/for/privacy/">For Privacy</a>
         <a href="/for/teams/" aria-current="page">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
-        <a href="/#download" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta">Download</a>
       </nav>
     </div>
   </header>
@@ -64,7 +65,7 @@
         <p class="persona-hero-message">Every AI action auditable. Auto-approval rules define what agents can do unattended. Credentials never touch the AI provider. Local execution by design.</p>
         <div class="persona-hero-cta">
           <a href="/security/" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
-          <a href="/#download" class="btn-secondary">Download for macOS</a>
+          <a href="/download/" class="btn-secondary">Download for macOS</a>
         </div>
       </div>
     </section>
@@ -168,7 +169,7 @@
         <h2 id="cta-heading">AI governance built in, not bolted on.</h2>
         <p>Prosponsive is the personal autonomous agent platform where every AI action is auditable, credentials are isolated, and data never leaves the machine.</p>
         <a href="/security/" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
-        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Or <a href="/#download" style="color:rgba(244,246,244,0.85);">download Prosponsive</a> to evaluate directly &middot; macOS &amp; Windows</p>
+        <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Or <a href="/download/" style="color:rgba(244,246,244,0.85);">download Prosponsive</a> to evaluate directly &middot; macOS &amp; Windows</p>
       </div>
     </section>
 

--- a/how-it-works/index.html
+++ b/how-it-works/index.html
@@ -43,6 +43,7 @@
         <a href="/for/power-users/">For Developers</a>
         <a href="/for/consultants/">For Consultants</a>
         <a href="/for/privacy/">For Privacy</a>
+        <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/" aria-current="page">How It Works</a>
         <a href="../guides/user-guide.html">Guides</a>
         <a href="/download/" class="nav-cta">Download</a>

--- a/how-it-works/index.html
+++ b/how-it-works/index.html
@@ -39,12 +39,13 @@
         <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
       </a>
       <nav class="site-nav" aria-label="Main navigation">
+        <a href="/">Home</a>
         <a href="/for/power-users/">For Developers</a>
         <a href="/for/consultants/">For Consultants</a>
         <a href="/for/privacy/">For Privacy</a>
         <a href="/how-it-works/" aria-current="page">How It Works</a>
         <a href="../guides/user-guide.html">Guides</a>
-        <a href="/#download" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta">Download</a>
       </nav>
     </div>
   </header>
@@ -63,7 +64,7 @@
         <h1 id="hero-heading">The bottleneck isn't the model. It's the architecture.</h1>
         <p class="persona-hero-message">Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. Here's why that matters and how it works.</p>
         <div class="persona-hero-cta">
-          <a href="/#download" class="btn-download">Download for macOS</a>
+          <a href="/download/" class="btn-download">Download for macOS</a>
           <a href="../guides/user-guide.html" class="btn-secondary">Read the user guide</a>
         </div>
       </div>
@@ -201,7 +202,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">AI That Works While You Don't</h2>
         <p>Prosponsive is the personal autonomous agent platform that runs AI assistants locally on your desktop. Free to download for macOS and Windows. 7+ AI providers. 2,533 tools. 12 languages.</p>
-        <a href="/#download" class="btn-download">Download for macOS</a>
+        <a href="/download/" class="btn-download">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows &middot; 12 languages</p>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive — AI That Works While You Don't</title>
-  <meta name="description" content="Personal autonomous agent platform for macOS and Windows. AI agents run tools in the background, in parallel — your data stays on your machine.">
+  <meta name="description" content="AI That Works While You Don't — AI agents run tools in the background, in parallel, with your data staying on your machine. Free for macOS and Windows.">
   <link rel="canonical" href="https://prosponsive.ai/">
   <meta property="og:title" content="Prosponsive — AI That Works While You Don't">
-  <meta property="og:description" content="Personal autonomous agent platform for macOS and Windows. AI agents run tools in the background, in parallel — your data stays on your machine.">
+  <meta property="og:description" content="AI That Works While You Don't — AI agents run tools in the background, in parallel, with your data staying on your machine. Free for macOS and Windows.">
   <meta property="og:url" content="https://prosponsive.ai/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Prosponsive — AI That Works While You Don't">
-  <meta name="twitter:description" content="Personal autonomous agent platform for macOS and Windows. AI agents run tools in the background, in parallel — your data stays on your machine.">
+  <meta name="twitter:description" content="AI That Works While You Don't — AI agents run tools in the background, in parallel, with your data staying on your machine. Free for macOS and Windows.">
   <link rel="icon" href="assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="assets/icon.png?v=2026-05-04">

--- a/security/index.html
+++ b/security/index.html
@@ -43,13 +43,14 @@
         <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
       </a>
       <nav class="site-nav" aria-label="Main navigation">
+        <a href="/">Home</a>
         <a href="/for/power-users/">For Developers</a>
         <a href="/for/consultants/">For Consultants</a>
         <a href="/for/privacy/">For Privacy</a>
         <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../guides/user-guide.html">Guides</a>
-        <a href="/#download" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta">Download</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
## Summary

- All `/#download` hrefs across inner pages now point to `/download/` — the actual download page
- Added "Home" link to the header nav on all inner pages (for/, how-it-works/, security/)
- The Prosponsive logo continues to link to `/`

## Pages updated
- `for/power-users/index.html`
- `for/consultants/index.html`
- `for/privacy/index.html`
- `for/teams/index.html`
- `how-it-works/index.html`
- `security/index.html`