### PR TITLE
feat: /integrations/ catalog page + site header/footer on all guide pages

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1605,3 +1605,103 @@ footer a:focus-visible {
     width: 3.5rem;
   }
 }
+
+/* ================================================================
+   Integrations Catalog
+   ================================================================ */
+
+.catalog-search-wrap {
+  max-width: 600px;
+  margin: 0 auto 1rem;
+}
+
+#catalog-search {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  font-family: var(--font-stack);
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  outline: none;
+}
+
+#catalog-search:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(47, 79, 62, 0.15);
+}
+
+#catalog-count {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.catalog-category {
+  margin-bottom: 2.5rem;
+}
+
+.catalog-category-heading {
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 1rem;
+  padding-bottom: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.875rem;
+}
+
+.catalog-card {
+  background-color: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1.25rem;
+}
+
+.catalog-card h3 {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 0.375rem;
+}
+
+.catalog-card p {
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  line-height: 1.5;
+  margin: 0 0 0.5rem;
+}
+
+.catalog-ops {
+  font-size: 0.75rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.catalog-footer-note {
+  font-size: 0.875rem;
+  color: var(--text-secondary);
+  text-align: center;
+  margin-top: 2rem;
+}
+
+.catalog-footer-note a {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+@media (max-width: 900px) {
+  .catalog-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 600px) {
+  .catalog-grid { grid-template-columns: 1fr; }
+}

--- a/guides/basics.html
+++ b/guides/basics.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
 <div class="guide-nav">
   <a href="install-guide.html">&larr; Install Guide</a>

--- a/guides/basics.html
+++ b/guides/basics.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">Basics</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="install-guide.html">&larr; Install Guide</a>
@@ -273,9 +287,21 @@
   <a href="features.html">Features &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="compare/">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -50,13 +50,27 @@
   .compare-card a { font-weight: 500; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">Comparison Guides</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="../n8n-workflow-developer-guide.html">&larr; Developer Guide</a>
@@ -208,9 +222,21 @@
   <span></span>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="./">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -71,6 +71,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="../user-guide.html">Guides</a><span aria-hidden="true"> › </span><a href="./">Compare</a></nav>
 
 <div class="guide-nav">
   <a href="../n8n-workflow-developer-guide.html">&larr; Developer Guide</a>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">vs. Zapier and Make</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="vs-copilot-workspace.html">&larr; vs. Copilot &amp; Workspace AI</a>
@@ -205,9 +219,21 @@
   <a href="vs-local-models.html">vs. Local Model Runners &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="./">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="../user-guide.html">Guides</a><span aria-hidden="true"> › </span><a href="./">Compare</a></nav>
 
 <div class="guide-nav">
   <a href="vs-copilot-workspace.html">&larr; vs. Copilot &amp; Workspace AI</a>

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="../user-guide.html">Guides</a><span aria-hidden="true"> › </span><a href="./">Compare</a></nav>
 
 <div class="guide-nav">
   <a href="vs-openclaw.html">&larr; vs. OpenClaw</a>

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">vs. Claude Cowork</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="vs-openclaw.html">&larr; vs. OpenClaw</a>
@@ -231,9 +245,21 @@
   <a href="vs-cloud-chat.html">vs. ChatGPT, Claude.ai &amp; Gemini &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="./">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">vs. ChatGPT, Claude.ai, and Gemini</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="vs-claude-cowork.html">&larr; vs. Claude Cowork</a>
@@ -201,9 +215,21 @@
   <a href="vs-copilot-workspace.html">vs. Copilot &amp; Workspace AI &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="./">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="../user-guide.html">Guides</a><span aria-hidden="true"> › </span><a href="./">Compare</a></nav>
 
 <div class="guide-nav">
   <a href="vs-claude-cowork.html">&larr; vs. Claude Cowork</a>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">vs. Microsoft Copilot and Google Workspace AI</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="vs-cloud-chat.html">&larr; vs. ChatGPT, Claude.ai &amp; Gemini</a>
@@ -210,9 +224,21 @@
   <a href="vs-automation.html">vs. Automation Platforms &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="./">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="../user-guide.html">Guides</a><span aria-hidden="true"> › </span><a href="./">Compare</a></nav>
 
 <div class="guide-nav">
   <a href="vs-cloud-chat.html">&larr; vs. ChatGPT, Claude.ai &amp; Gemini</a>

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="../user-guide.html">Guides</a><span aria-hidden="true"> › </span><a href="./">Compare</a></nav>
 
 <div class="guide-nav">
   <a href="vs-local-models.html">&larr; vs. Local Model Runners</a>

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">vs. Custom GPTs and OpenAI Assistants</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="vs-local-models.html">&larr; vs. Local Model Runners</a>
@@ -222,9 +236,21 @@
   <a href="index.html">All Comparisons &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="./">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="../user-guide.html">Guides</a><span aria-hidden="true"> › </span><a href="./">Compare</a></nav>
 
 <div class="guide-nav">
   <a href="vs-automation.html">&larr; vs. Automation Platforms</a>

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">vs. Ollama, LM Studio, and GPT4All</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="vs-automation.html">&larr; vs. Automation Platforms</a>
@@ -203,9 +217,21 @@
   <a href="vs-custom-agents.html">vs. Custom GPTs &amp; Assistants &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="./">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">vs. OpenClaw</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="index.html">&larr; All Comparisons</a>
@@ -272,9 +286,21 @@
   <a href="vs-claude-cowork.html">vs. Claude Cowork &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="../user-guide.html">Guides</a>
+      <a href="./">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="../user-guide.html">Guides</a><span aria-hidden="true"> › </span><a href="./">Compare</a></nav>
 
 <div class="guide-nav">
   <a href="index.html">&larr; All Comparisons</a>

--- a/guides/email-assistant-example.html
+++ b/guides/email-assistant-example.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
 <div class="guide-nav">
   <a href="features.html">&larr; Features</a>

--- a/guides/email-assistant-example.html
+++ b/guides/email-assistant-example.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">Example: Email Assistant</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="features.html">&larr; Features</a>
@@ -376,9 +390,21 @@
   <a href="feedback.html">Feedback &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="compare/">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/features.html
+++ b/guides/features.html
@@ -79,6 +79,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
 <div class="guide-nav">
   <a href="basics.html">&larr; Basics</a>

--- a/guides/features.html
+++ b/guides/features.html
@@ -19,15 +19,15 @@
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -58,13 +58,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">Feature Guide</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="basics.html">&larr; Basics</a>
@@ -517,9 +531,21 @@
   <a href="email-assistant-example.html">Email Assistant &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="compare/">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
 <div class="guide-nav">
   <a href="email-assistant-example.html">&larr; Email Assistant</a>

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">Feedback &amp; Philosophy</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="email-assistant-example.html">&larr; Email Assistant</a>
@@ -151,9 +165,21 @@
   <a href="n8n-workflow-developer-guide.html">Developer Guide &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="compare/">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/install-guide.html
+++ b/guides/install-guide.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
 <div class="guide-nav">
   <span></span>

--- a/guides/install-guide.html
+++ b/guides/install-guide.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">Install Guide</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <span></span>
@@ -230,9 +244,21 @@
   <a href="basics.html">Prosponsive Basics &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="compare/">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/n8n-tool-building-guide.html
+++ b/guides/n8n-tool-building-guide.html
@@ -66,6 +66,10 @@
 <div class="guide-content">
 <nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
+<div class="guide-nav">
+  <a href="user-guide.html">&larr; Guides</a>
+</div>
+
 <h1>Building Tools with n8n</h1>
 
 <p>Tools in Prosponsive are <a href="https://n8n.io">n8n</a> workflows. When you build a workflow that follows the conventions in this guide, Prosponsive automatically discovers it and makes it available to your agents. This guide covers how to structure your workflows, how to design their output for the best display in Prosponsive, and how to connect incoming data to outgoing tool calls.</p>
@@ -424,6 +428,9 @@ POST /api/ai/agent-inference
 
 <hr>
 
+<div class="guide-nav">
+  <a href="user-guide.html">&larr; Guides</a>
+</div>
 
 </div>
 

--- a/guides/n8n-tool-building-guide.html
+++ b/guides/n8n-tool-building-guide.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -43,13 +43,27 @@
   .section-number { color: #4F6F5C; font-weight: 400; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">Building Tools with n8n</div>
-  <div class="version">A guide to creating n8n workflows that work as Prosponsive agent tools</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <h1>Building Tools with n8n</h1>
 
@@ -409,9 +423,21 @@ POST /api/ai/agent-inference
 
 <hr>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="compare/">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/n8n-tool-building-guide.html
+++ b/guides/n8n-tool-building-guide.html
@@ -64,6 +64,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
 <h1>Building Tools with n8n</h1>
 

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-nav a:hover { text-decoration: underline; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">Building Tools with n8n</div>
-  <div class="version">A guide to creating n8n workflows that work as Prosponsive agent tools</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <div class="guide-nav">
   <a href="feedback.html">&larr; Feedback</a>
@@ -422,9 +436,21 @@ POST /api/ai/agent-inference
   <a href="compare/">How Prosponsive Compares &rarr;</a>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> &mdash; Personal Autonomous Agent Platform
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="compare/">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
 <div class="guide-nav">
   <a href="feedback.html">&larr; Feedback</a>

--- a/guides/user-guide.html
+++ b/guides/user-guide.html
@@ -7,15 +7,15 @@
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
     color: #1F2321 !important;
     background-color: #F4F6F4 !important;
     line-height: 1.6;
-    max-width: 7.5in;
-    margin: 0 auto;
   }
+  .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
   h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
   h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
   h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
@@ -46,13 +46,27 @@
   .guide-card p { margin: 0.4em 0; }
   </style>
 </head>
-<body>
+<body class="page-wrapper">
 
-<div class="cover">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="cover-wordmark">
-  <div class="tagline">User Guide</div>
-  <div class="version">Personal Autonomous Agent Platform</div>
-</div>
+<header class="site-header">
+  <div class="site-header-inner">
+    <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+      <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+    </a>
+    <nav class="site-nav" aria-label="Main navigation">
+      <a href="/">Home</a>
+      <a href="/for/power-users/">For Developers</a>
+      <a href="/for/consultants/">For Consultants</a>
+      <a href="/for/privacy/">For Privacy</a>
+      <a href="/for/teams/">For Teams</a>
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="/download/" class="nav-cta">Download</a>
+    </nav>
+  </div>
+</header>
+
+<div class="guide-content">
 
 <h1>Prosponsive User Guide</h1>
 
@@ -93,11 +107,21 @@
   <p>Side-by-side comparisons with OpenClaw, Claude Cowork, ChatGPT, Copilot, Zapier, local model runners, and Custom GPTs. Honest architectural differences, not marketing claims.</p>
 </div>
 
-<div style="text-align: center; margin-top: 3em; padding-top: 1em; border-top: 2px solid #D6DBD7; color: #5C635F; font-size: 0.85em; margin-bottom: 3em;">
-  <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive" class="footer-wordmark"> — Personal Autonomous Agent Platform
-  <br><br>
-  <p>&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+
 </div>
+
+<footer>
+  <div class="footer-inner">
+    <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+    <nav class="footer-nav" aria-label="Footer links">
+      <a href="/how-it-works/">How It Works</a>
+      <a href="user-guide.html">Guides</a>
+      <a href="compare/">Compare</a>
+      <a href="/releases/">Release Notes</a>
+      <a href="/legal/">Legal</a>
+    </nav>
+  </div>
+</footer>
 
 </body>
 </html>

--- a/guides/user-guide.html
+++ b/guides/user-guide.html
@@ -67,6 +67,7 @@
 </header>
 
 <div class="guide-content">
+<nav class="breadcrumb" aria-label="Breadcrumb" style="margin-bottom:1.5rem;"><a href="/">Home</a><span aria-hidden="true"> › </span><a href="user-guide.html">Guides</a></nav>
 
 <h1>Prosponsive User Guide</h1>
 

--- a/index.html
+++ b/index.html
@@ -211,7 +211,7 @@
             <p><a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products — one agent call executes a complete workflow: read a ticket, look up the customer, check billing, and draft the response as a single operation.</p>
             <p>Not trigger-action automation. Not single MCP calls. Prosponsive agents use n8n-powered tools that coordinate across your real systems — Salesforce, NetSuite, Workday, ServiceNow — in one step, with 60–80% fewer tool calls compared to equivalent MCP stacks.</p>
             <div class="pillar-cta">
-              <a href="guides/n8n-tool-building-guide.html" class="btn-secondary">Browse integrations</a>
+              <a href="/integrations/" class="btn-secondary">Browse integrations</a>
             </div>
           </div>
           <div class="pillar-metrics-panel" aria-label="Pillar 03 metrics">

--- a/integrations/index.html
+++ b/integrations/index.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Integrations &mdash; Prosponsive</title>
-  <meta name="description" content="Browse 2,533 pre-built integrations across 216 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
+  <meta name="description" content="Browse 2,533 pre-built integrations across 215 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
   <link rel="canonical" href="https://prosponsive.ai/integrations/">
   <meta property="og:title" content="Integrations &mdash; Prosponsive">
-  <meta property="og:description" content="Browse 2,533 pre-built integrations across 216 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
+  <meta property="og:description" content="Browse 2,533 pre-built integrations across 215 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
   <meta property="og:url" content="https://prosponsive.ai/integrations/">
   <meta property="og:type" content="website">
   <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Integrations &mdash; Prosponsive">
-  <meta name="twitter:description" content="Browse 2,533 pre-built integrations across 216 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
+  <meta name="twitter:description" content="Browse 2,533 pre-built integrations across 215 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
@@ -25,7 +25,7 @@
     "@id": "https://prosponsive.ai/integrations/#webpage",
     "url": "https://prosponsive.ai/integrations/",
     "name": "Integrations — Prosponsive",
-    "description": "Browse 2,533 pre-built integrations across 216 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.",
+    "description": "Browse 2,533 pre-built integrations across 215 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.",
     "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
   }
   </script>
@@ -61,7 +61,7 @@
     <!-- Hero -->
     <section class="persona-hero" aria-labelledby="hero-heading">
       <div class="section-inner">
-        <h1 id="hero-heading">2,533 integrations. 216 systems.</h1>
+        <h1 id="hero-heading">2,533 integrations. 215 systems.</h1>
         <p class="persona-hero-message">Connect the tools your work runs on. Every integration runs through n8n's isolated container &mdash; your credentials never touch the agent runtime.</p>
       </div>
     </section>
@@ -75,7 +75,7 @@
           <label for="catalog-search" class="visually-hidden">Search integrations</label>
           <input type="text" id="catalog-search" placeholder="Search integrations..." autocomplete="off" spellcheck="false">
         </div>
-        <p id="catalog-count">Showing 215 of 216 systems</p>
+        <p id="catalog-count">Showing 215 of 215 systems</p>
 
   <div class="catalog-category" id="cat-crm-sales">
     <h2 class="catalog-category-heading">CRM &amp; Sales</h2>
@@ -1077,7 +1077,7 @@
           section.style.display = anyVisible ? '' : 'none';
         });
 
-        countEl.textContent = 'Showing ' + visible + ' of 216 systems';
+        countEl.textContent = 'Showing ' + visible + ' of 215 systems';
       });
     })();
   </script>

--- a/integrations/index.html
+++ b/integrations/index.html
@@ -1,0 +1,1086 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Integrations &mdash; Prosponsive</title>
+  <meta name="description" content="Browse 2,533 pre-built integrations across 216 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
+  <link rel="canonical" href="https://prosponsive.ai/integrations/">
+  <meta property="og:title" content="Integrations &mdash; Prosponsive">
+  <meta property="og:description" content="Browse 2,533 pre-built integrations across 216 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
+  <meta property="og:url" content="https://prosponsive.ai/integrations/">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="https://prosponsive.ai/assets/prosponsive-logo-icon.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Integrations &mdash; Prosponsive">
+  <meta name="twitter:description" content="Browse 2,533 pre-built integrations across 216 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.">
+  <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
+  <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
+  <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
+  <link rel="stylesheet" href="../css/styles.css">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "WebPage",
+    "@id": "https://prosponsive.ai/integrations/#webpage",
+    "url": "https://prosponsive.ai/integrations/",
+    "name": "Integrations — Prosponsive",
+    "description": "Browse 2,533 pre-built integrations across 216 systems. Connect Salesforce, NetSuite, Workday, ServiceNow, and hundreds more through Prosponsive's n8n-powered tool runtime.",
+    "isPartOf": { "@id": "https://prosponsive.ai/#organization" }
+  }
+  </script>
+</head>
+<body class="page-wrapper">
+
+  <!-- Site Header -->
+  <header class="site-header">
+    <div class="site-header-inner">
+      <a href="/" class="site-header-logo" aria-label="Prosponsive home">
+        <img src="../assets/prosponsive-wordmark.svg" alt="Prosponsive">
+      </a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href="/">Home</a>
+        <a href="/for/power-users/">For Developers</a>
+        <a href="/for/consultants/">For Consultants</a>
+        <a href="/for/privacy/">For Privacy</a>
+        <a href="/for/teams/">For Teams</a>
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../guides/user-guide.html">Guides</a>
+        <a href="/download/" class="nav-cta">Download</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main-content">
+
+    <!-- Breadcrumb -->
+    <div class="breadcrumb section-inner" style="padding-top:1rem;padding-bottom:1rem;">
+      <a href="/">Home</a><span aria-hidden="true"> &rsaquo; </span>Integrations
+    </div>
+
+    <!-- Hero -->
+    <section class="persona-hero" aria-labelledby="hero-heading">
+      <div class="section-inner">
+        <h1 id="hero-heading">2,533 integrations. 216 systems.</h1>
+        <p class="persona-hero-message">Connect the tools your work runs on. Every integration runs through n8n's isolated container &mdash; your credentials never touch the agent runtime.</p>
+      </div>
+    </section>
+
+    <!-- Search + Catalog -->
+    <section aria-labelledby="catalog-heading">
+      <div class="section-inner">
+        <h2 id="catalog-heading" class="visually-hidden">Integration catalog</h2>
+
+        <div class="catalog-search-wrap">
+          <label for="catalog-search" class="visually-hidden">Search integrations</label>
+          <input type="text" id="catalog-search" placeholder="Search integrations..." autocomplete="off" spellcheck="false">
+        </div>
+        <p id="catalog-count">Showing 215 of 216 systems</p>
+
+  <div class="catalog-category" id="cat-crm-sales">
+    <h2 class="catalog-category-heading">CRM &amp; Sales</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="affinity ">
+      <h3>Affinity</h3>
+      <span class="catalog-ops">16 operations</span>
+    </div>
+    <div class="catalog-card" data-search="agile crm ">
+      <h3>Agile CRM</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    <div class="catalog-card" data-search="clearbit ">
+      <h3>Clearbit</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="copper ">
+      <h3>Copper</h3>
+      <span class="catalog-ops">32 operations</span>
+    </div>
+    <div class="catalog-card" data-search="dropcontact find b2b emails and enrich contacts">
+      <h3>Dropcontact</h3>
+      <p>Find B2B emails and enrich contacts</p>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="freshworks crm ">
+      <h3>Freshworks CRM</h3>
+      <span class="catalog-ops">32 operations</span>
+    </div>
+    <div class="catalog-card" data-search="gong interact with gong api">
+      <h3>Gong</h3>
+      <p>Interact with Gong API</p>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="highlevel consume highlevel api v2">
+      <h3>HighLevel</h3>
+      <p>Consume HighLevel API v2</p>
+      <span class="catalog-ops">17 operations</span>
+    </div>
+    <div class="catalog-card" data-search="hubspot ">
+      <h3>HubSpot</h3>
+      <span class="catalog-ops">31 operations</span>
+    </div>
+    <div class="catalog-card" data-search="humantic ai ">
+      <h3>Humantic AI</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="keap ">
+      <h3>Keap</h3>
+      <span class="catalog-ops">28 operations</span>
+    </div>
+    <div class="catalog-card" data-search="lonescale create list, add / delete items">
+      <h3>LoneScale</h3>
+      <p>Create List, add / delete items</p>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="monica crm ">
+      <h3>Monica CRM</h3>
+      <span class="catalog-ops">52 operations</span>
+    </div>
+    <div class="catalog-card" data-search="pipedrive create and edit data in pipedrive">
+      <h3>Pipedrive</h3>
+      <p>Create and edit data in Pipedrive</p>
+      <span class="catalog-ops">49 operations</span>
+    </div>
+    <div class="catalog-card" data-search="salesforce ">
+      <h3>Salesforce</h3>
+      <span class="catalog-ops">65 operations</span>
+    </div>
+    <div class="catalog-card" data-search="salesmate ">
+      <h3>Salesmate</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    <div class="catalog-card" data-search="uplead ">
+      <h3>Uplead</h3>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="zoho crm ">
+      <h3>Zoho CRM</h3>
+      <span class="catalog-ops">61 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-marketing">
+    <h2 class="catalog-category-heading">Marketing</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="activecampaign create and edit data in activecampaign">
+      <h3>ActiveCampaign</h3>
+      <p>Create and edit data in ActiveCampaign</p>
+      <span class="catalog-ops">48 operations</span>
+    </div>
+    <div class="catalog-card" data-search="autopilot ">
+      <h3>Autopilot</h3>
+      <span class="catalog-ops">11 operations</span>
+    </div>
+    <div class="catalog-card" data-search="brevo ">
+      <h3>Brevo</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    <div class="catalog-card" data-search="convertkit ">
+      <h3>ConvertKit</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    <div class="catalog-card" data-search="customer.io ">
+      <h3>Customer.io</h3>
+      <span class="catalog-ops">9 operations</span>
+    </div>
+    <div class="catalog-card" data-search="e-goi ">
+      <h3>E-goi</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="emelia ">
+      <h3>Emelia</h3>
+      <span class="catalog-ops">9 operations</span>
+    </div>
+    <div class="catalog-card" data-search="facebook graph api interacts with facebook using the graph api">
+      <h3>Facebook Graph API</h3>
+      <p>Interacts with Facebook using the Graph API</p>
+    </div>
+    <div class="catalog-card" data-search="getresponse ">
+      <h3>GetResponse</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="hunter ">
+      <h3>Hunter</h3>
+    </div>
+    <div class="catalog-card" data-search="iterable ">
+      <h3>Iterable</h3>
+      <span class="catalog-ops">6 operations</span>
+    </div>
+    <div class="catalog-card" data-search="lemlist ">
+      <h3>Lemlist</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    <div class="catalog-card" data-search="linkedin ">
+      <h3>LinkedIn</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="mailcheck ">
+      <h3>Mailcheck</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="mailchimp ">
+      <h3>Mailchimp</h3>
+      <span class="catalog-ops">14 operations</span>
+    </div>
+    <div class="catalog-card" data-search="mailerlite ">
+      <h3>MailerLite</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="mailgun sends an email via mailgun">
+      <h3>Mailgun</h3>
+      <p>Sends an email via Mailgun</p>
+    </div>
+    <div class="catalog-card" data-search="mailjet ">
+      <h3>Mailjet</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="mandrill ">
+      <h3>Mandrill</h3>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="mautic ">
+      <h3>Mautic</h3>
+      <span class="catalog-ops">20 operations</span>
+    </div>
+    <div class="catalog-card" data-search="medium ">
+      <h3>Medium</h3>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="phantombuster ">
+      <h3>Phantombuster</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="posthog ">
+      <h3>PostHog</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="segment ">
+      <h3>Segment</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="sendgrid ">
+      <h3>SendGrid</h3>
+      <span class="catalog-ops">10 operations</span>
+    </div>
+    <div class="catalog-card" data-search="sendy ">
+      <h3>Sendy</h3>
+      <span class="catalog-ops">6 operations</span>
+    </div>
+    <div class="catalog-card" data-search="tapfiliate ">
+      <h3>Tapfiliate</h3>
+      <span class="catalog-ops">12 operations</span>
+    </div>
+    <div class="catalog-card" data-search="vero ">
+      <h3>Vero</h3>
+      <span class="catalog-ops">8 operations</span>
+    </div>
+    <div class="catalog-card" data-search="x (formerly twitter) post, like, and search tweets, send messages, search users, and add users to lists">
+      <h3>X (Formerly Twitter)</h3>
+      <p>Post, like, and search tweets, send messages, search users, and add users to lists</p>
+      <span class="catalog-ops">8 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-finance-billing">
+    <h2 class="catalog-category-heading">Finance &amp; Billing</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="beeminder ">
+      <h3>Beeminder</h3>
+      <span class="catalog-ops">18 operations</span>
+    </div>
+    <div class="catalog-card" data-search="chargebee retrieve data from chargebee api">
+      <h3>Chargebee</h3>
+      <p>Retrieve data from Chargebee API</p>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="coingecko ">
+      <h3>CoinGecko</h3>
+      <span class="catalog-ops">9 operations</span>
+    </div>
+    <div class="catalog-card" data-search="harvest access data on harvest">
+      <h3>Harvest</h3>
+      <p>Access data on Harvest</p>
+      <span class="catalog-ops">51 operations</span>
+    </div>
+    <div class="catalog-card" data-search="invoice ninja ">
+      <h3>Invoice Ninja</h3>
+      <span class="catalog-ops">31 operations</span>
+    </div>
+    <div class="catalog-card" data-search="marketstack ">
+      <h3>Marketstack</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="paddle ">
+      <h3>Paddle</h3>
+      <span class="catalog-ops">9 operations</span>
+    </div>
+    <div class="catalog-card" data-search="profitwell ">
+      <h3>ProfitWell</h3>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="quickbooks online ">
+      <h3>QuickBooks Online</h3>
+      <span class="catalog-ops">42 operations</span>
+    </div>
+    <div class="catalog-card" data-search="stripe ">
+      <h3>Stripe</h3>
+      <span class="catalog-ops">20 operations</span>
+    </div>
+    <div class="catalog-card" data-search="xero ">
+      <h3>Xero</h3>
+      <span class="catalog-ops">8 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-hr-people">
+    <h2 class="catalog-category-heading">HR &amp; People</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="bamboohr ">
+      <h3>BambooHR</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-project-management">
+    <h2 class="catalog-category-heading">Project Management</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="adalo ">
+      <h3>Adalo</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="airtable read, update, write and delete data from airtable">
+      <h3>Airtable</h3>
+      <p>Read, update, write and delete data from Airtable</p>
+      <span class="catalog-ops">8 operations</span>
+    </div>
+    <div class="catalog-card" data-search="asana ">
+      <h3>Asana</h3>
+      <span class="catalog-ops">22 operations</span>
+    </div>
+    <div class="catalog-card" data-search="baserow ">
+      <h3>Baserow</h3>
+      <span class="catalog-ops">8 operations</span>
+    </div>
+    <div class="catalog-card" data-search="bubble ">
+      <h3>Bubble</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="clickup consume clickup api (beta)">
+      <h3>ClickUp</h3>
+      <p>Consume ClickUp API (Beta)</p>
+      <span class="catalog-ops">57 operations</span>
+    </div>
+    <div class="catalog-card" data-search="cockpit ">
+      <h3>Cockpit</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="coda ">
+      <h3>Coda</h3>
+      <span class="catalog-ops">18 operations</span>
+    </div>
+    <div class="catalog-card" data-search="currents interact with the currents api for test orchestration and analytics">
+      <h3>Currents</h3>
+      <p>Interact with the Currents API for test orchestration and analytics</p>
+      <span class="catalog-ops">22 operations</span>
+    </div>
+    <div class="catalog-card" data-search="data table permanently save data across workflow executions in a table">
+      <h3>Data table</h3>
+      <p>Permanently save data across workflow executions in a table</p>
+      <span class="catalog-ops">11 operations</span>
+    </div>
+    <div class="catalog-card" data-search="jira software ">
+      <h3>Jira Software</h3>
+      <span class="catalog-ops">20 operations</span>
+    </div>
+    <div class="catalog-card" data-search="kobotoolbox work with kobotoolbox forms and submissions">
+      <h3>KoBoToolbox</h3>
+      <p>Work with KoBoToolbox forms and submissions</p>
+      <span class="catalog-ops">17 operations</span>
+    </div>
+    <div class="catalog-card" data-search="linear ">
+      <h3>Linear</h3>
+      <span class="catalog-ops">7 operations</span>
+    </div>
+    <div class="catalog-card" data-search="monday.com ">
+      <h3>Monday.com</h3>
+      <span class="catalog-ops">18 operations</span>
+    </div>
+    <div class="catalog-card" data-search="nocodb read, update, write and delete data from nocodb">
+      <h3>NocoDB</h3>
+      <p>Read, update, write and delete data from NocoDB</p>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="notion ">
+      <h3>Notion</h3>
+      <span class="catalog-ops">14 operations</span>
+    </div>
+    <div class="catalog-card" data-search="quick base integrate with the quick base restful api">
+      <h3>Quick Base</h3>
+      <p>Integrate with the Quick Base RESTful API</p>
+      <span class="catalog-ops">10 operations</span>
+    </div>
+    <div class="catalog-card" data-search="seatable ">
+      <h3>SeaTable</h3>
+      <span class="catalog-ops">16 operations</span>
+    </div>
+    <div class="catalog-card" data-search="stackby read, write, and delete data in stackby">
+      <h3>Stackby</h3>
+      <p>Read, write, and delete data in Stackby</p>
+    </div>
+    <div class="catalog-card" data-search="taiga ">
+      <h3>Taiga</h3>
+      <span class="catalog-ops">20 operations</span>
+    </div>
+    <div class="catalog-card" data-search="todoist ">
+      <h3>Todoist</h3>
+      <span class="catalog-ops">36 operations</span>
+    </div>
+    <div class="catalog-card" data-search="trello create, change and delete boards and cards">
+      <h3>Trello</h3>
+      <p>Create, change and delete boards and cards</p>
+      <span class="catalog-ops">41 operations</span>
+    </div>
+    <div class="catalog-card" data-search="wekan ">
+      <h3>Wekan</h3>
+      <span class="catalog-ops">24 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-communication">
+    <h2 class="catalog-category-heading">Communication</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="discord ">
+      <h3>Discord</h3>
+      <span class="catalog-ops">14 operations</span>
+    </div>
+    <div class="catalog-card" data-search="drift ">
+      <h3>Drift</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="gotify ">
+      <h3>Gotify</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="home assistant ">
+      <h3>Home Assistant</h3>
+      <span class="catalog-ops">13 operations</span>
+    </div>
+    <div class="catalog-card" data-search="intercom ">
+      <h3>Intercom</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    <div class="catalog-card" data-search="line ">
+      <h3>Line</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="matrix ">
+      <h3>Matrix</h3>
+      <span class="catalog-ops">11 operations</span>
+    </div>
+    <div class="catalog-card" data-search="mattermost ">
+      <h3>Mattermost</h3>
+      <span class="catalog-ops">19 operations</span>
+    </div>
+    <div class="catalog-card" data-search="messagebird sends sms via messagebird">
+      <h3>MessageBird</h3>
+      <p>Sends SMS via MessageBird</p>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="mocean send sms and voice messages via mocean">
+      <h3>Mocean</h3>
+      <p>Send SMS and voice messages via Mocean</p>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="msg91 sends transactional sms via msg91">
+      <h3>MSG91</h3>
+      <p>Sends transactional SMS via MSG91</p>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="philips hue ">
+      <h3>Philips Hue</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="plivo send sms/mms messages or make phone calls">
+      <h3>Plivo</h3>
+      <p>Send SMS/MMS messages or make phone calls</p>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="pushbullet ">
+      <h3>Pushbullet</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="pushcut ">
+      <h3>Pushcut</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="pushover ">
+      <h3>Pushover</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="rocketchat ">
+      <h3>RocketChat</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="seven send sms and make text-to-speech calls">
+      <h3>seven</h3>
+      <p>Send SMS and make text-to-speech calls</p>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="signl4 ">
+      <h3>SIGNL4</h3>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="slack ">
+      <h3>Slack</h3>
+      <span class="catalog-ops">44 operations</span>
+    </div>
+    <div class="catalog-card" data-search="telegram ">
+      <h3>Telegram</h3>
+      <span class="catalog-ops">24 operations</span>
+    </div>
+    <div class="catalog-card" data-search="twake ">
+      <h3>Twake</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="twilio send sms and whatsapp messages or make phone calls">
+      <h3>Twilio</h3>
+      <p>Send SMS and WhatsApp messages or make phone calls</p>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="twist ">
+      <h3>Twist</h3>
+      <span class="catalog-ops">22 operations</span>
+    </div>
+    <div class="catalog-card" data-search="vonage ">
+      <h3>Vonage</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="whatsapp business cloud access whatsapp api">
+      <h3>WhatsApp Business Cloud</h3>
+      <p>Access WhatsApp API</p>
+      <span class="catalog-ops">6 operations</span>
+    </div>
+    <div class="catalog-card" data-search="zulip ">
+      <h3>Zulip</h3>
+      <span class="catalog-ops">16 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-developer-tools">
+    <h2 class="catalog-category-heading">Developer Tools</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="amqp sender sends a raw-message via amqp 1.0, executed once per item">
+      <h3>AMQP Sender</h3>
+      <p>Sends a raw-message via AMQP 1.0, executed once per item</p>
+    </div>
+    <div class="catalog-card" data-search="aws lambda invoke functions on aws lambda">
+      <h3>AWS Lambda</h3>
+      <p>Invoke functions on AWS Lambda</p>
+    </div>
+    <div class="catalog-card" data-search="bitwarden ">
+      <h3>Bitwarden</h3>
+      <span class="catalog-ops">19 operations</span>
+    </div>
+    <div class="catalog-card" data-search="circleci ">
+      <h3>CircleCI</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="cloudflare ">
+      <h3>Cloudflare</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="compression compress and decompress files">
+      <h3>Compression</h3>
+      <p>Compress and decompress files</p>
+    </div>
+    <div class="catalog-card" data-search="cratedb ">
+      <h3>CrateDB</h3>
+    </div>
+    <div class="catalog-card" data-search="crypto provide cryptographic utilities">
+      <h3>Crypto</h3>
+      <p>Provide cryptographic utilities</p>
+    </div>
+    <div class="catalog-card" data-search="erpnext ">
+      <h3>ERPNext</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="execute command executes a command on the host">
+      <h3>Execute Command</h3>
+      <p>Executes a command on the host</p>
+    </div>
+    <div class="catalog-card" data-search="git control git.">
+      <h3>Git</h3>
+      <p>Control git.</p>
+    </div>
+    <div class="catalog-card" data-search="github ">
+      <h3>GitHub</h3>
+      <span class="catalog-ops">37 operations</span>
+    </div>
+    <div class="catalog-card" data-search="gitlab retrieve data from gitlab api">
+      <h3>GitLab</h3>
+      <p>Retrieve data from GitLab API</p>
+      <span class="catalog-ops">18 operations</span>
+    </div>
+    <div class="catalog-card" data-search="graphql makes a graphql request and returns the received data">
+      <h3>GraphQL</h3>
+      <p>Makes a GraphQL request and returns the received data</p>
+    </div>
+    <div class="catalog-card" data-search="http request makes an http request and returns the response data">
+      <h3>HTTP Request</h3>
+      <p>Makes an HTTP request and returns the response data</p>
+    </div>
+    <div class="catalog-card" data-search="jenkins ">
+      <h3>Jenkins</h3>
+      <span class="catalog-ops">11 operations</span>
+    </div>
+    <div class="catalog-card" data-search="jwt jwt">
+      <h3>JWT</h3>
+      <p>JWT</p>
+    </div>
+    <div class="catalog-card" data-search="kafka sends messages to a kafka topic">
+      <h3>Kafka</h3>
+      <p>Sends messages to a Kafka topic</p>
+    </div>
+    <div class="catalog-card" data-search="ldap interact with ldap servers">
+      <h3>Ldap</h3>
+      <p>Interact with LDAP servers</p>
+    </div>
+    <div class="catalog-card" data-search="lingvanex ">
+      <h3>LingvaNex</h3>
+    </div>
+    <div class="catalog-card" data-search="mongodb ">
+      <h3>MongoDB</h3>
+      <span class="catalog-ops">11 operations</span>
+    </div>
+    <div class="catalog-card" data-search="mqtt push messages to mqtt">
+      <h3>MQTT</h3>
+      <p>Push messages to MQTT</p>
+    </div>
+    <div class="catalog-card" data-search="mysql ">
+      <h3>MySQL</h3>
+      <span class="catalog-ops">6 operations</span>
+    </div>
+    <div class="catalog-card" data-search="netlify ">
+      <h3>Netlify</h3>
+      <span class="catalog-ops">7 operations</span>
+    </div>
+    <div class="catalog-card" data-search="npm ">
+      <h3>Npm</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="postgres ">
+      <h3>Postgres</h3>
+      <span class="catalog-ops">6 operations</span>
+    </div>
+    <div class="catalog-card" data-search="questdb ">
+      <h3>QuestDB</h3>
+    </div>
+    <div class="catalog-card" data-search="rabbitmq sends messages to a rabbitmq topic">
+      <h3>RabbitMQ</h3>
+      <p>Sends messages to a RabbitMQ topic</p>
+    </div>
+    <div class="catalog-card" data-search="redis get, send and update data in redis">
+      <h3>Redis</h3>
+      <p>Get, send and update data in Redis</p>
+    </div>
+    <div class="catalog-card" data-search="rundeck manage rundeck api">
+      <h3>Rundeck</h3>
+      <p>Manage Rundeck API</p>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="s3 ">
+      <h3>S3</h3>
+      <span class="catalog-ops">12 operations</span>
+    </div>
+    <div class="catalog-card" data-search="snowflake ">
+      <h3>Snowflake</h3>
+    </div>
+    <div class="catalog-card" data-search="splunk ">
+      <h3>Splunk</h3>
+      <span class="catalog-ops">16 operations</span>
+    </div>
+    <div class="catalog-card" data-search="supabase add, get, delete and update data in a table">
+      <h3>Supabase</h3>
+      <p>Add, get, delete and update data in a table</p>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="timescaledb ">
+      <h3>TimescaleDB</h3>
+    </div>
+    <div class="catalog-card" data-search="totp generate a time-based one-time password">
+      <h3>TOTP</h3>
+      <p>Generate a time-based one-time password</p>
+    </div>
+    <div class="catalog-card" data-search="travisci ">
+      <h3>TravisCI</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-data-analytics">
+    <h2 class="catalog-category-heading">Data &amp; Analytics</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="airtop scrape and control any site with airtop">
+      <h3>Airtop</h3>
+      <p>Scrape and control any site with Airtop</p>
+      <span class="catalog-ops">24 operations</span>
+    </div>
+    <div class="catalog-card" data-search="brandfetch ">
+      <h3>Brandfetch</h3>
+    </div>
+    <div class="catalog-card" data-search="contentful ">
+      <h3>Contentful</h3>
+      <span class="catalog-ops">7 operations</span>
+    </div>
+    <div class="catalog-card" data-search="databricks interact with databricks api">
+      <h3>Databricks</h3>
+      <p>Interact with Databricks API</p>
+      <span class="catalog-ops">36 operations</span>
+    </div>
+    <div class="catalog-card" data-search="date &amp; time manipulate date and time values">
+      <h3>Date &amp; Time</h3>
+      <p>Manipulate date and time values</p>
+    </div>
+    <div class="catalog-card" data-search="deepl translate data using deepl">
+      <h3>DeepL</h3>
+      <p>Translate data using DeepL</p>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="grafana ">
+      <h3>Grafana</h3>
+      <span class="catalog-ops">16 operations</span>
+    </div>
+    <div class="catalog-card" data-search="grist ">
+      <h3>Grist</h3>
+    </div>
+    <div class="catalog-card" data-search="hacker news ">
+      <h3>Hacker News</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="jina ai interact with jina ai api">
+      <h3>Jina AI</h3>
+      <p>Interact with Jina AI API</p>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="metabase use the metabase api">
+      <h3>Metabase</h3>
+      <p>Use the Metabase API</p>
+      <span class="catalog-ops">10 operations</span>
+    </div>
+    <div class="catalog-card" data-search="misp ">
+      <h3>MISP</h3>
+      <span class="catalog-ops">44 operations</span>
+    </div>
+    <div class="catalog-card" data-search="mistral ai ">
+      <h3>Mistral AI</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="nasa retrieve data from the nasa api">
+      <h3>NASA</h3>
+      <p>Retrieve data from the NASA API</p>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    <div class="catalog-card" data-search="one simple api a toolbox of no-code utilities">
+      <h3>One Simple API</h3>
+      <p>A toolbox of no-code utilities</p>
+      <span class="catalog-ops">10 operations</span>
+    </div>
+    <div class="catalog-card" data-search="openthesaurus get synonmns for german words using the openthesaurus api">
+      <h3>OpenThesaurus</h3>
+      <p>Get synonmns for German words using the OpenThesaurus API</p>
+    </div>
+    <div class="catalog-card" data-search="openweathermap gets current and future weather information">
+      <h3>OpenWeatherMap</h3>
+      <p>Gets current and future weather information</p>
+    </div>
+    <div class="catalog-card" data-search="perplexity ai-powered answer engine that provides accurate, trusted, and real-time answers to any question. supports chat completions, agent responses, web search, and embeddings.">
+      <h3>Perplexity</h3>
+      <p>AI-powered answer engine that provides accurate, trusted, and real-time answers to any question. Supports chat completions, agent responses, web search, and embeddings.</p>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="rss read reads data from an rss feed">
+      <h3>RSS Read</h3>
+      <p>Reads data from an RSS Feed</p>
+    </div>
+    <div class="catalog-card" data-search="securityscorecard ">
+      <h3>SecurityScorecard</h3>
+      <span class="catalog-ops">19 operations</span>
+    </div>
+    <div class="catalog-card" data-search="sentry.io ">
+      <h3>Sentry.io</h3>
+      <span class="catalog-ops">25 operations</span>
+    </div>
+    <div class="catalog-card" data-search="storyblok ">
+      <h3>Storyblok</h3>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="thehive ">
+      <h3>TheHive</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="thehive 5 ">
+      <h3>TheHive 5</h3>
+      <span class="catalog-ops">48 operations</span>
+    </div>
+    <div class="catalog-card" data-search="urlscan.io provides various utilities for monitoring websites like health checks or screenshots">
+      <h3>urlscan.io</h3>
+      <p>Provides various utilities for monitoring websites like health checks or screenshots</p>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-e-commerce">
+    <h2 class="catalog-category-heading">E-commerce</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="dhl ">
+      <h3>DHL</h3>
+      <span class="catalog-ops">1 operation</span>
+    </div>
+    <div class="catalog-card" data-search="magento 2 ">
+      <h3>Magento 2</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    <div class="catalog-card" data-search="onfleet ">
+      <h3>Onfleet</h3>
+      <span class="catalog-ops">37 operations</span>
+    </div>
+    <div class="catalog-card" data-search="shopify ">
+      <h3>Shopify</h3>
+      <span class="catalog-ops">10 operations</span>
+    </div>
+    <div class="catalog-card" data-search="unleashed software ">
+      <h3>Unleashed Software</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="woocommerce ">
+      <h3>WooCommerce</h3>
+      <span class="catalog-ops">15 operations</span>
+    </div>
+    </div>
+  </div>
+
+  <div class="catalog-category" id="cat-productivity">
+    <h2 class="catalog-category-heading">Productivity</h2>
+    <div class="catalog-grid">
+    <div class="catalog-card" data-search="action network ">
+      <h3>Action Network</h3>
+      <span class="catalog-ops">23 operations</span>
+    </div>
+    <div class="catalog-card" data-search="apitemplate.io ">
+      <h3>APITemplate.io</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="bitly ">
+      <h3>Bitly</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="clockify ">
+      <h3>Clockify</h3>
+      <span class="catalog-ops">25 operations</span>
+    </div>
+    <div class="catalog-card" data-search="demio ">
+      <h3>Demio</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="discourse ">
+      <h3>Discourse</h3>
+      <span class="catalog-ops">16 operations</span>
+    </div>
+    <div class="catalog-card" data-search="dropbox access data on dropbox">
+      <h3>Dropbox</h3>
+      <p>Access data on Dropbox</p>
+      <span class="catalog-ops">11 operations</span>
+    </div>
+    <div class="catalog-card" data-search="filemaker retrieve data from the filemaker data api">
+      <h3>FileMaker</h3>
+      <p>Retrieve data from the FileMaker data API</p>
+    </div>
+    <div class="catalog-card" data-search="freshdesk ">
+      <h3>Freshdesk</h3>
+      <span class="catalog-ops">10 operations</span>
+    </div>
+    <div class="catalog-card" data-search="freshservice ">
+      <h3>Freshservice</h3>
+      <span class="catalog-ops">72 operations</span>
+    </div>
+    <div class="catalog-card" data-search="ghost ">
+      <h3>Ghost</h3>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="gotowebinar ">
+      <h3>GoToWebinar</h3>
+      <span class="catalog-ops">22 operations</span>
+    </div>
+    <div class="catalog-card" data-search="halopsa ">
+      <h3>HaloPSA</h3>
+      <span class="catalog-ops">20 operations</span>
+    </div>
+    <div class="catalog-card" data-search="help scout ">
+      <h3>Help Scout</h3>
+      <span class="catalog-ops">13 operations</span>
+    </div>
+    <div class="catalog-card" data-search="nextcloud access data on nextcloud">
+      <h3>Nextcloud</h3>
+      <p>Access data on Nextcloud</p>
+      <span class="catalog-ops">17 operations</span>
+    </div>
+    <div class="catalog-card" data-search="odoo ">
+      <h3>Odoo</h3>
+      <span class="catalog-ops">20 operations</span>
+    </div>
+    <div class="catalog-card" data-search="okta use the okta api">
+      <h3>Okta</h3>
+      <p>Use the Okta API</p>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="oura ">
+      <h3>Oura</h3>
+      <span class="catalog-ops">4 operations</span>
+    </div>
+    <div class="catalog-card" data-search="pagerduty ">
+      <h3>PagerDuty</h3>
+      <span class="catalog-ops">9 operations</span>
+    </div>
+    <div class="catalog-card" data-search="peekalink ">
+      <h3>Peekalink</h3>
+    </div>
+    <div class="catalog-card" data-search="postbin ">
+      <h3>PostBin</h3>
+      <span class="catalog-ops">6 operations</span>
+    </div>
+    <div class="catalog-card" data-search="quickchart create a chart via quickchart">
+      <h3>QuickChart</h3>
+      <p>Create a chart via QuickChart</p>
+    </div>
+    <div class="catalog-card" data-search="raindrop ">
+      <h3>Raindrop</h3>
+      <span class="catalog-ops">13 operations</span>
+    </div>
+    <div class="catalog-card" data-search="reddit ">
+      <h3>Reddit</h3>
+      <span class="catalog-ops">13 operations</span>
+    </div>
+    <div class="catalog-card" data-search="send email sends an email using smtp protocol">
+      <h3>Send Email</h3>
+      <p>Sends an email using SMTP protocol</p>
+      <span class="catalog-ops">2 operations</span>
+    </div>
+    <div class="catalog-card" data-search="servicenow ">
+      <h3>ServiceNow</h3>
+      <span class="catalog-ops">25 operations</span>
+    </div>
+    <div class="catalog-card" data-search="spotify access public song data via the spotify api">
+      <h3>Spotify</h3>
+      <p>Access public song data via the Spotify API</p>
+      <span class="catalog-ops">30 operations</span>
+    </div>
+    <div class="catalog-card" data-search="strapi ">
+      <h3>Strapi</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="strava ">
+      <h3>Strava</h3>
+      <span class="catalog-ops">9 operations</span>
+    </div>
+    <div class="catalog-card" data-search="syncromsp gets data from syncromsp">
+      <h3>SyncroMSP</h3>
+      <p>Gets data from SyncroMSP</p>
+      <span class="catalog-ops">20 operations</span>
+    </div>
+    <div class="catalog-card" data-search="uproc ">
+      <h3>uProc</h3>
+    </div>
+    <div class="catalog-card" data-search="uptimerobot ">
+      <h3>UptimeRobot</h3>
+      <span class="catalog-ops">21 operations</span>
+    </div>
+    <div class="catalog-card" data-search="webflow ">
+      <h3>Webflow</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    <div class="catalog-card" data-search="wordpress ">
+      <h3>Wordpress</h3>
+      <span class="catalog-ops">12 operations</span>
+    </div>
+    <div class="catalog-card" data-search="yourls ">
+      <h3>Yourls</h3>
+      <span class="catalog-ops">3 operations</span>
+    </div>
+    <div class="catalog-card" data-search="zammad ">
+      <h3>Zammad</h3>
+      <span class="catalog-ops">21 operations</span>
+    </div>
+    <div class="catalog-card" data-search="zendesk ">
+      <h3>Zendesk</h3>
+      <span class="catalog-ops">23 operations</span>
+    </div>
+    <div class="catalog-card" data-search="zoom ">
+      <h3>Zoom</h3>
+      <span class="catalog-ops">5 operations</span>
+    </div>
+    </div>
+  </div>
+
+        <p class="catalog-footer-note">Powered by <a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> &mdash; build custom workflows with any system n8n supports.</p>
+
+      </div>
+    </section>
+
+  </main>
+
+  <!-- Footer -->
+  <footer>
+    <div class="footer-inner">
+      <p class="footer-copy">&copy; 2026 Prosponsive, Inc. All rights reserved.</p>
+      <nav class="footer-nav" aria-label="Footer links">
+        <a href="/how-it-works/">How It Works</a>
+        <a href="../guides/user-guide.html">Guides</a>
+        <a href="../guides/compare/">Compare</a>
+        <a href="../releases/">Release Notes</a>
+        <a href="/legal/">Legal</a>
+      </nav>
+    </div>
+  </footer>
+
+  <script>
+    (function () {
+      var searchInput = document.getElementById('catalog-search');
+      var countEl = document.getElementById('catalog-count');
+      var allCards = document.querySelectorAll('.catalog-card');
+      var allCategories = document.querySelectorAll('.catalog-category');
+      var totalSystems = allCards.length;
+
+      searchInput.addEventListener('input', function () {
+        var query = searchInput.value.trim().toLowerCase();
+        var visible = 0;
+
+        allCards.forEach(function (card) {
+          var match = !query || card.dataset.search.indexOf(query) !== -1;
+          card.style.display = match ? '' : 'none';
+          if (match) visible++;
+        });
+
+        // Hide/show entire category sections
+        allCategories.forEach(function (section) {
+          var anyVisible = false;
+          section.querySelectorAll('.catalog-card').forEach(function (card) {
+            if (card.style.display !== 'none') anyVisible = true;
+          });
+          section.style.display = anyVisible ? '' : 'none';
+        });
+
+        countEl.textContent = 'Showing ' + visible + ' of 216 systems';
+      });
+    })();
+  </script>
+
+</body>
+</html>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -21,6 +21,13 @@
   </url>
 
   <url>
+    <loc>https://prosponsive.ai/integrations/</loc>
+    <lastmod>2026-06-03</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
     <loc>https://prosponsive.ai/for/power-users/</loc>
     <lastmod>2026-06-03</lastmod>
     <changefreq>monthly</changefreq>


### PR DESCRIPTION
## Summary

- New `/integrations/` page: all 215 n8n-powered systems, grouped by category, with live client-side search. Data baked in from the Prosponsive app catalog JSON.
- All guide pages (`guides/*.html` and `guides/compare/*.html`) now have the common site header (sticky nav) and `.footer-inner` footer. Cover/wordmark sections removed.
- Breadcrumb navigation added to all guide pages (Home → Guides → [Compare] path).
- Count display fixed: shows 215 of 215 (E2E Test node excluded).
- "Browse integrations" button on home page and power-users page updated to `/integrations/`.

Closes #84