### PR TITLE
fix: scope guide inline styles to .guide-content, fix integrations section structure

### DIFF
--- a/guides/basics.html
+++ b/guides/basics.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/email-assistant-example.html
+++ b/guides/email-assistant-example.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/features.html
+++ b/guides/features.html
@@ -28,22 +28,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/install-guide.html
+++ b/guides/install-guide.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/n8n-tool-building-guide.html
+++ b/guides/n8n-tool-building-guide.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/security-architecture-whitepaper.html
+++ b/guides/security-architecture-whitepaper.html
@@ -17,22 +17,22 @@
     max-width: 7.5in;
     margin: 0 auto;
   }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/user-guide.html
+++ b/guides/user-guide.html
@@ -16,22 +16,22 @@
     line-height: 1.6;
   }
   .guide-content { max-width: 7.5in; margin: 0 auto; padding: 2rem 1.5rem; }
-  h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
-  h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
-  h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
-  a { color: #2F4F3E; text-decoration: underline; }
-  code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
-  pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
-  pre code { background: none; padding: 0; }
-  blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
-  blockquote p { margin: 0.3em 0; }
-  table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
-  th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
-  td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
-  tr:nth-child(even) td { background: #F4F6F4; }
-  strong { color: #2F4F3E; }
-  hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
-  li { margin-bottom: 0.3em; }
+  .guide-content h1 { color: #2F4F3E; font-size: 2em; border-bottom: 3px solid #2F4F3E; padding-bottom: 0.4em; margin-top: 0; }
+  .guide-content h2 { color: #2F4F3E; font-size: 1.4em; border-bottom: 1px solid #D6DBD7; padding-bottom: 0.3em; margin-top: 2em; page-break-after: avoid; }
+  .guide-content h3 { color: #3A5F4A; font-size: 1.1em; margin-top: 1.5em; page-break-after: avoid; }
+  .guide-content a { color: #2F4F3E; text-decoration: underline; }
+  .guide-content code { background: #E6EAE7; padding: 0.15em 0.4em; border-radius: 4px; font-size: 0.9em; font-family: 'SF Mono', Menlo, Monaco, Consolas, monospace; }
+  .guide-content pre { background: #E6EAE7; border-left: 4px solid #2F4F3E; padding: 0.8em 1em; border-radius: 4px; overflow-x: auto; page-break-inside: avoid; }
+  .guide-content pre code { background: none; padding: 0; }
+  .guide-content blockquote { border-left: 4px solid #4F6F5C; background: #F4F6F4; margin: 1em 0; padding: 0.6em 1em; border-radius: 0 4px 4px 0; color: #3A5F4A; page-break-inside: avoid; }
+  .guide-content blockquote p { margin: 0.3em 0; }
+  .guide-content table { border-collapse: collapse; width: 100%; margin: 1em 0; font-size: 0.9em; page-break-inside: avoid; }
+  .guide-content th { background: #2F4F3E; color: white; padding: 0.5em 0.8em; text-align: left; font-weight: 600; }
+  .guide-content td { padding: 0.5em 0.8em; border-bottom: 1px solid #D6DBD7; }
+  .guide-content tr:nth-child(even) td { background: #F4F6F4; }
+  .guide-content strong { color: #2F4F3E; }
+  .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
+  .guide-content li { margin-bottom: 0.3em; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/integrations/index.html
+++ b/integrations/index.html
@@ -77,6 +77,10 @@
         </div>
         <p id="catalog-count">Showing 215 of 215 systems</p>
 
+      </div><!-- /.section-inner (search box) -->
+
+      <div class="section-inner" style="padding-top:1.5rem;">
+
   <div class="catalog-category" id="cat-crm-sales">
     <h2 class="catalog-category-heading">CRM &amp; Sales</h2>
     <div class="catalog-grid">


### PR DESCRIPTION
- Scope all unscoped CSS selectors (h1, h2, a, code, table, etc.) in guide page inline styles to .guide-content to prevent bleeding into site header/footer
- Fix integrations page: close section-inner before catalog categories and re-wrap catalog with reduced top padding