### PR TITLE
fix: restore list indentation and paragraph spacing in guide pages

### DIFF
--- a/guides/basics.html
+++ b/guides/basics.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/email-assistant-example.html
+++ b/guides/email-assistant-example.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/features.html
+++ b/guides/features.html
@@ -44,6 +44,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/install-guide.html
+++ b/guides/install-guide.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/n8n-tool-building-guide.html
+++ b/guides/n8n-tool-building-guide.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/security-architecture-whitepaper.html
+++ b/guides/security-architecture-whitepaper.html
@@ -33,6 +33,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }

--- a/guides/user-guide.html
+++ b/guides/user-guide.html
@@ -32,6 +32,8 @@
   .guide-content strong { color: #2F4F3E; }
   .guide-content hr { border: none; border-top: 2px solid #D6DBD7; margin: 2em 0; }
   .guide-content li { margin-bottom: 0.3em; }
+  .guide-content ul, .guide-content ol { padding-left: 2em; margin: 0.75em 0; }
+  .guide-content p { margin: 0.5em 0; }
   .cover { text-align: center; padding: 2em 0 1em 0; }
   .cover-wordmark { width: 360px; max-width: 90%; height: auto; display: block; margin: 0 auto; }
   .footer-wordmark { height: 28px; width: auto; vertical-align: middle; margin-right: 0.4em; }


### PR DESCRIPTION
CSS reset stripped ul/ol padding and p margins. Adds .guide-content scoped rules.