### PR TITLE
feat(#88): PostHog analytics — full funnel tracking from website to download

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,40 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Substitute build-time tokens
+        env:
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+        run: |
+          find . -name "*.html" -not -path "./.git/*" \
+            -exec sed -i "s/__POSTHOG_API_KEY__/${POSTHOG_API_KEY}/g" {} +
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/docs/specs/88-posthog-funnel-analytics.md
+++ b/docs/specs/88-posthog-funnel-analytics.md
@@ -1,0 +1,518 @@
+# Spec 88 — PostHog Analytics: Full Funnel Tracking
+
+**Issue:** [jb-brown/Prosponsive.ai#88](https://github.com/jb-brown/Prosponsive.ai/issues/88)
+**Status:** Draft — pending review
+**Type:** Implementation spec (marketing site instrumentation + identity-stitch design)
+**Scope split:** Marketing site (this repo) — implemented here. App-side instrumentation — deferred to linked Prosponsive repo issue (see §6).
+
+---
+
+## Table of Contents
+
+1. [Goal and Funnel Definition](#1-goal-and-funnel-definition)
+2. [Constraints and Non-Negotiables](#2-constraints-and-non-negotiables)
+3. [PostHog Integration — Marketing Site](#3-posthog-integration--marketing-site)
+   - 3.1 [Snippet Deployment Strategy](#31-snippet-deployment-strategy)
+   - 3.2 [Initialization Configuration](#32-initialization-configuration)
+   - 3.3 [Page View Tracking](#33-page-view-tracking)
+   - 3.4 [CTA Click Events](#34-cta-click-events)
+   - 3.5 [UTM Attribution](#35-utm-attribution)
+4. [Identity Stitching Design](#4-identity-stitching-design)
+   - 4.1 [Web Session Identity (steps 1–2 — this PR)](#41-web-session-identity-steps-12--this-pr)
+   - 4.2 [App-Side Identity (steps 3–5 — deferred)](#42-app-side-identity-steps-35--deferred)
+5. [PostHog Funnel Dashboard](#5-posthog-funnel-dashboard)
+6. [Deferred Scope — App-Side Issue](#6-deferred-scope--app-side-issue)
+7. [PII Constraints](#7-pii-constraints)
+8. [Open Questions for User Decision](#8-open-questions-for-user-decision)
+9. [Acceptance Criteria](#9-acceptance-criteria)
+
+---
+
+## 1. Goal and Funnel Definition
+
+Instrument the complete user acquisition funnel so conversion can be measured at every stage:
+
+```
+Website visit
+    ↓  [pageview — tracked on this PR]
+CTA click / download button
+    ↓  [download_click event — tracked on this PR]
+Installer download initiated (ph_id stitched into URL — tracked on this PR)
+    ↓
+App first launch
+    ↓  [app_first_launch — deferred, app-side issue]
+Auth completed (Clerk sign-in)
+    ↓  [auth_completed + posthog.identify() — deferred]
+Purchase / subscription
+    ↓  [subscription_purchased — deferred, Stripe webhook → PostHog]
+Continued use
+    ↓  [session_started, agent_run — deferred]
+```
+
+The hard problem is **identity stitching**: connecting the anonymous web visitor UUID to the authenticated Clerk user so all six stages collapse into a single PostHog person profile. The design for this is in §4.
+
+---
+
+## 2. Constraints and Non-Negotiables
+
+**Site architecture (ground truth — these are facts, not assumptions):**
+- Static GitHub Pages site. No build step, no bundler, no npm, no template/partial system.
+- All pages are hand-authored HTML files sharing one stylesheet (`css/styles.css`) and, where needed, one JS file (`js/download.js`).
+- HTML files exist at: `index.html`, `download/index.html`, and one `index.html` per section directory: `for/`, `guides/`, `how-it-works/`, `integrations/`, `legal/`, `privacy/`, `releases/`, `security/`, `terms/`. The `guides/` and `for/` directories contain multiple HTML files each.
+- `js/download.js` is the only existing JS module. It handles platform detection, version fetching from CloudFront manifests, download URL construction, and DOM updates for the download button. The `ph_id` work attaches here.
+
+**PostHog loading constraint:** posthog-js must be loaded via the PostHog CDN async snippet (a `<script>` tag calling the PostHog loader). An npm import is not possible given the no-bundler constraint.
+
+**PostHog project:** reuse the existing PostHog Cloud project and API key already in use by the Electron app. Do NOT create a separate project. Both web and app events land in the same project so person profiles span both surfaces.
+
+**Analytics must never block UX:** all PostHog calls are fire-and-forget. No event send should be awaited in a way that delays page interaction or download initiation.
+
+**PII discipline:** see §7.
+
+---
+
+## 3. PostHog Integration — Marketing Site
+
+### 3.1 Snippet Deployment Strategy
+
+The site has no shared template or partial system, so the PostHog snippet must be added to every HTML file individually. There are approximately 32 HTML files across the site (counted from the repo).
+
+**Mechanism:** add the PostHog CDN async snippet immediately before `</head>` in every HTML file. The snippet is self-contained and does not depend on any other JS on the page.
+
+**Shared analytics module:** to keep the CTA click event logic maintainable and avoid duplicating it across 32 files, create a new file `js/analytics.js`. This file:
+- Assumes `posthog` is already initialized by the inline snippet.
+- Exports nothing (vanilla IIFE) — attaches event listeners on `DOMContentLoaded`.
+- Captures CTA click events (§3.4) by querying the DOM for known CTA selectors.
+- Handles the `ph_id` download-URL stamping (§4.1).
+
+Every HTML page that has a CTA link includes `<script src="/js/analytics.js"></script>` (or the appropriate relative path) before `</body>`. Pages without CTAs (e.g., pure legal/terms pages) do not need this script, but still need the snippet for page view tracking.
+
+**File change surface summary:**
+- All ~32 HTML files: add PostHog snippet to `<head>`.
+- HTML files with download CTAs or high-value links: add `<script src="...js/analytics.js"></script>` before `</body>`.
+- `js/analytics.js`: new file (see §3.4).
+- `js/download.js`: modified to stamp `ph_id` into download URLs (see §4.1).
+
+### 3.2 Initialization Configuration
+
+The PostHog CDN async snippet placed in every HTML `<head>` must initialize with this configuration:
+
+```html
+<script>
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('<POSTHOG_API_KEY>', {
+    api_host: 'https://us.i.posthog.com',
+    autocapture: false,
+    capture_pageview: true,
+    persistence: 'localStorage+cookie',
+    cross_subdomain_cookie: false,
+    disable_session_recording: true,
+    loaded: function(ph) {
+      // ph_id stamping runs here via analytics.js after init confirms loaded
+    }
+  });
+</script>
+```
+
+Configuration decisions:
+- `autocapture: false` — explicit events only (§3.4). Autocapture produces noisy, hard-to-interpret data for a simple funnel.
+- `capture_pageview: true` — automatic `$pageview` on every page load. This covers all pages without additional code.
+- `persistence: 'localStorage+cookie'` — PostHog default; stores the anonymous `distinct_id` in both localStorage and a cookie named `ph_<key>_posthog`. The cookie form is needed for the `ph_id` stitch (§4.1) because localStorage is origin-scoped and not readable by other origins, but the cookie can be set with attributes the app can inspect if needed.
+- `cross_subdomain_cookie: false` — prosponsive.ai has no subdomains requiring shared identity.
+- `disable_session_recording: true` — not needed for funnel analytics; keeps data lean and avoids capturing sensitive user input.
+- `autocapture: false` and `disable_session_recording: true` together mean PostHog sends no data without an explicit event call.
+- `<POSTHOG_API_KEY>` — use the existing key from the Electron app. This is a public write-only key (safe to embed in client HTML).
+
+**Note on the `api_host` value:** the Electron app uses `https://us.i.posthog.com`. Use the same host to ensure events land in the same project and are processed by the same pipeline.
+
+### 3.3 Page View Tracking
+
+`capture_pageview: true` in the init config causes PostHog to fire a `$pageview` event automatically on every page load. No additional code is required.
+
+PostHog automatically enriches `$pageview` with:
+- `$current_url` (full URL including query string — UTM params captured here)
+- `$host`, `$pathname`
+- `$referrer`, `$referring_domain`
+- Browser/OS properties
+
+This covers every page in the site including the download page, persona pages, guides, compare pages, legal pages, etc. No per-page additions are needed beyond the snippet.
+
+### 3.4 CTA Click Events
+
+`js/analytics.js` attaches click listeners to high-value CTAs on `DOMContentLoaded`. All events use `posthog.capture()` and fire synchronously before the browser follows the link (the download link case is handled specially — see §4.1).
+
+**Events to capture:**
+
+#### `download_click`
+
+Fired when the user clicks the primary download button (element `id="download-btn"` in `download/index.html` and any download button on other pages with `class="btn-download"`).
+
+Properties:
+```js
+{
+  platform: 'macos' | 'windows' | 'unknown',  // from download.js detectPlatform()
+  cta_location: 'download_page' | 'home_hero' | 'nav' | 'inline',  // where on the page
+  utm_source: <string | null>,
+  utm_medium: <string | null>,
+  utm_campaign: <string | null>,
+  utm_content: <string | null>,
+  utm_term: <string | null>
+}
+```
+
+The `platform` value must be read from the button's current text content or from the `href` attribute (which `download.js` sets to `.../latest` for macOS or `.../latest-win` for Windows) — do not re-run platform detection in analytics.js. Read `btn.href` and derive platform from the URL suffix.
+
+The `cta_location` value is determined by a `data-cta-location` attribute that the code agent adds to each download button at the HTML level:
+- `download/index.html` `#download-btn` → `data-cta-location="download_page"`
+- `index.html` hero download button (if present) → `data-cta-location="home_hero"`
+- Nav download link → `data-cta-location="nav"`
+- Other in-page download links → `data-cta-location="inline"`
+
+Adding `data-cta-location` to each button is an HTML change, not a JS change — the code agent handles this as part of implementing this spec.
+
+**CRITICAL: download URL stamping must happen BEFORE the browser navigates.** The `download_click` event capture and the `ph_id` URL stamping (§4.1) both execute in the same click handler. The download link must not navigate until after the URL has been stamped. Implementation: attach the click listener with `e.preventDefault()`, stamp the URL, capture the event, then programmatically follow the link with `window.location.href = btn.href`.
+
+#### `cta_click`
+
+Fired for hero and section CTAs that are not the primary download button but represent high-intent engagement. Captured on elements with `class="btn-secondary"` and on pricing/contact links if they exist.
+
+Properties:
+```js
+{
+  cta_text: <string>,         // button/link text content (trimmed)
+  cta_href: <string>,         // destination URL
+  cta_location: <string>,     // data-cta-location attribute value
+  utm_source: <string | null>,
+  utm_medium: <string | null>,
+  utm_campaign: <string | null>
+}
+```
+
+High-value `btn-secondary` CTAs to instrument (based on current site content):
+- "See how it works" → `/how-it-works/`
+- "Read security architecture" → `/security/`
+- "Browse integrations" → `/integrations/`
+- Persona card links (`.persona-card` anchors on `index.html`)
+
+For persona card clicks, use `cta_location: 'persona_grid'` and `cta_text: <card heading text>`.
+
+#### `pricing_viewed`
+
+If a pricing section or `/pricing/` page exists at implementation time, fire this event on scroll into view (use `IntersectionObserver` on the pricing section element) with:
+```js
+{ utm_source, utm_medium, utm_campaign }
+```
+
+If no pricing section exists when this spec is implemented, skip this event — do not add an observer to a non-existent element.
+
+### 3.5 UTM Attribution
+
+PostHog's `capture_pageview: true` automatically captures the full URL including query params. UTM parameters (`utm_source`, `utm_medium`, `utm_campaign`, `utm_content`, `utm_term`) present in the URL at page load time are automatically stored in the PostHog person profile under `initial_utm_*` properties on first touch, and as session properties on every subsequent touch.
+
+No custom UTM-parsing code is needed for page view attribution — PostHog handles it.
+
+For click events, `analytics.js` must read UTM params from `window.location.search` at the time the click fires and attach them as properties. This ensures the click event carries campaign context even if PostHog's session properties are not yet flushed.
+
+UTM reader helper (add to `analytics.js`):
+```js
+function readUTMs() {
+  var params = new URLSearchParams(window.location.search);
+  return {
+    utm_source:   params.get('utm_source'),
+    utm_medium:   params.get('utm_medium'),
+    utm_campaign: params.get('utm_campaign'),
+    utm_content:  params.get('utm_content'),
+    utm_term:     params.get('utm_term')
+  };
+}
+```
+
+---
+
+## 4. Identity Stitching Design
+
+The full stitch spans five steps. Steps 1–2 are implemented in this issue (marketing site). Steps 3–5 are deferred to the app-side issue.
+
+### 4.1 Web Session Identity (steps 1–2 — this PR)
+
+**Step 1 — PostHog assigns a `distinct_id` on first site visit.**
+
+When `posthog.init()` runs on the first visit, PostHog generates a UUID and stores it in localStorage and a cookie named `ph_<API_KEY>_posthog`. This happens automatically. The `distinct_id` value is accessible as `posthog.get_distinct_id()` after initialization.
+
+No code is needed to implement step 1 beyond the snippet in §3.2.
+
+**Step 2 — Stamp `ph_id` into the download URL before the browser follows it.**
+
+When the user clicks the download button, `analytics.js` modifies the `href` on `#download-btn` to append `?ph_id=<distinct_id>` before the navigation proceeds. The installer binary is downloaded from CloudFront; the `ph_id` query param is not consumed by CloudFront but is preserved in the browser's download URL bar and, more importantly, is available to the app on first launch via the mechanism described in step 3 (deferred).
+
+Implementation in `analytics.js` (within the `download_click` handler):
+
+```js
+var anonId = posthog.get_distinct_id();
+if (anonId) {
+  var url = new URL(btn.href, window.location.origin);
+  url.searchParams.set('ph_id', anonId);
+  btn.href = url.toString();
+}
+```
+
+This runs after `e.preventDefault()` and before the programmatic navigation that follows the link.
+
+**What this achieves:** the download URL that the browser follows carries the anonymous PostHog ID. The app can read this from the URL at first launch (step 3, deferred) and call `posthog.alias()` to merge the web visitor identity with the install identity.
+
+**What this does NOT achieve:** if the user downloads from a browser that blocks cookies/localStorage, `posthog.get_distinct_id()` may return a fresh UUID that does not match an existing web session. This is expected behavior — PostHog will simply create a new person. The email-match fallback (matching on Clerk email at auth time) is a team decision, not a shipping fallback. See §8.
+
+**Note on the email-match fallback:** the issue notes this as a potential alternative if installer complexity proves prohibitive. The decision point is: if the team later decides not to read `ph_id` from the download URL in the app (step 3), they can instead rely on PostHog's email-based identity merge at the `posthog.identify(clerkUserId, { email })` call (step 4). This would lose the web-visit-to-download linkage but preserve the download-to-auth linkage. This is not an equal alternative to ship alongside the `ph_id` stitch — it is a fallback the team may choose if the installer-parsing approach is not implemented. Document the decision in the app-side issue when step 3 is implemented.
+
+### 4.2 App-Side Identity (steps 3–5 — deferred)
+
+These steps are outside the scope of this issue and will be specified in the linked Prosponsive repo issue. Listed here for design completeness:
+
+**Step 3 — App first launch reads `ph_id`, calls `posthog.alias()`.**
+The Electron app inspects the download URL or installer metadata for `ph_id`. If found, calls `posthog.alias(ph_id, installId)` where `installId` is a stable device-scoped UUID. PostHog merges the web visitor profile and the install profile into one person.
+
+**Step 4 — Clerk sign-in triggers `posthog.identify()`.**
+On successful Clerk authentication, the app calls `posthog.identify(clerkUserId, { email, plan })`. PostHog merges the install identity into the authenticated person. At this point all three identities (web visitor, installer, Clerk user) are unified.
+
+**Step 5 — Stripe webhook sends server-side purchase event.**
+The existing commerce Lambda layer receives the Stripe `customer.subscription.created` (or `checkout.session.completed`) webhook and sends a `subscription_purchased` event to PostHog server-side using `posthog-node`, keyed to the `clerkUserId`. This is more reliable than client-side capture because it does not depend on the app being open at purchase time.
+
+---
+
+## 5. PostHog Funnel Dashboard
+
+Create a PostHog funnel visualization in the existing PostHog Cloud project with these five steps:
+
+| Step | PostHog Event | Source |
+|------|---------------|--------|
+| 1 | `$pageview` (any page) | Website — automatic |
+| 2 | `download_click` | Website — `analytics.js` |
+| 3 | `app_first_launch` | App — deferred |
+| 4 | `auth_completed` | App — deferred |
+| 5 | `subscription_purchased` | Lambda → PostHog server-side — deferred |
+
+**Dashboard configuration:**
+- Funnel type: Unique users, ordered steps.
+- Conversion window: 30 days (web visit to purchase is a long consideration cycle for this product).
+- Optional filter: `utm_source` property to slice by campaign.
+- Breakdown by `platform` on the `download_click` step to see macOS vs. Windows conversion rates.
+
+**Note:** steps 3–5 will show zero conversions until the app-side issue is implemented. The dashboard can be created now with the first two steps functional; add steps 3–5 as placeholders so the visualization is ready when app instrumentation ships.
+
+---
+
+## 6. Deferred Scope — App-Side Issue
+
+File a new issue in the **jb-brown/Prosponsive** repo titled:
+
+> "PostHog app-side instrumentation: first launch alias, Clerk identify, lifecycle events, Stripe webhook"
+
+The issue body must reference this spec (Prosponsive.ai#88) and cover:
+
+- First launch: read `ph_id` from download URL, call `posthog.alias(ph_id, installId)`.
+- Clerk sign-in: `posthog.identify(clerkUserId, { email, plan })`.
+- Lifecycle events: `app_first_launch`, `auth_completed`, `trial_started`, `session_started`, `agent_run`.
+- Stripe webhook → PostHog server-side `subscription_purchased` via the existing commerce Lambda layer (uses `posthog-node`; the PostHog write key must be added to the Lambda's environment).
+- The app already has `posthog-node` (main process) and `posthog-js` (renderer) dependencies per the issue. Confirm at implementation time.
+
+This issue is a blocker for funnel steps 3–5. The marketing site implementation (this issue) is not blocked by it.
+
+---
+
+## 7. PII Constraints
+
+The following rules apply to all event properties:
+
+- **Email** is allowed ONLY in `posthog.identify()` as a person property (`email`). Never put email in an event name or an event property on any captured event.
+- **Clerk user ID** is a pseudonymous identifier — acceptable as the `distinct_id` passed to `posthog.identify()` and as a property on `subscription_purchased`.
+- **IP address** — PostHog is initialized without `ip: true` override. PostHog Cloud does not persist the raw IP by default. Confirm in PostHog project settings that "Discard client IP data" is enabled to align with the app's existing configuration.
+- **Event names** are all lowercase with underscores. No user-authored content appears in event names.
+- **Event properties** must not contain: message content, file paths, API key fragments, or any text the user typed.
+- **Download URL after stamping** contains `ph_id` (a UUID). This is not PII. The `ph_id` param is not logged or stored server-side by CloudFront (CloudFront access logging is disabled per the privacy policy §4.2).
+
+---
+
+## 8. Open Questions for User Decision
+
+These questions are surfaced for the user to decide before implementation begins. The spec does not resolve them unilaterally.
+
+### Q1: Cookie consent / EU exposure
+
+**Context:** PostHog JS sets a localStorage entry and a cookie on first page load (before any click). The privacy policy (§4.2) currently describes PostHog analytics as opt-in via the desktop app. The marketing website does not currently mention web analytics. prosponsive.ai is US-focused; GDPR/ePrivacy Directive exposure depends on whether EU visitors are a meaningful audience.
+
+**Options:**
+- **A (recommended for now):** No consent banner. Update the privacy policy to disclose marketing site analytics. Reassess if EU expansion becomes a priority.
+- **B:** Add a minimal consent banner (cookie notice) before PostHog initializes. PostHog supports `posthog.opt_in_capturing()` / `posthog.opt_out_capturing()` for this pattern.
+- **C:** Initialize PostHog in cookieless mode (`persistence: 'memory'`) which avoids setting a persistent cookie but loses cross-visit identity (funnel step 1→2 still works within a session; cross-session attribution is lost).
+
+**Decision required:** the code agent must not proceed with snippet deployment until this is resolved. Option A is the working assumption unless the user selects otherwise.
+
+### Q2: Same PostHog project vs. separate project
+
+**Context:** the issue recommends reusing the existing PostHog Cloud project. This means web visitor profiles and app user profiles are merged in the same project, enabling the identity stitch.
+
+**Consequence of a separate project:** the identity stitch (§4) becomes impossible — there is no cross-project alias. Person profiles would be split across two projects with no linkage.
+
+**Recommendation:** same project (as stated in §2). No decision needed unless there is a reason to separate.
+
+### Q3: Server-side vs. client-side Stripe events
+
+**Context:** `subscription_purchased` can be sent to PostHog from: (a) the client app after receiving a webhook-driven subscription state update, or (b) the commerce Lambda directly on `checkout.session.completed`.
+
+**Recommendation:** server-side via the commerce Lambda (option b). It fires regardless of app state and cannot be blocked by the client. It requires the PostHog write key to be added to the Lambda's environment variables (a secret, not the public API key).
+
+**Decision required:** confirm server-side approach and authorize adding PostHog write key to the Lambda environment before the app-side issue is implemented.
+
+---
+
+## 9. Acceptance Criteria
+
+Tracing each acceptance criterion from the issue to this spec:
+
+| Criterion | Where addressed |
+|-----------|----------------|
+| posthog-js added to the marketing site using the existing PostHog Cloud project/API key | §3.1, §3.2 — CDN snippet on every page, same project |
+| Page views tracked on all marketing site pages | §3.3 — `capture_pageview: true` covers all pages automatically |
+| Download button clicks tracked with `{ platform, cta_location, utm_* }` properties | §3.4 — `download_click` event spec |
+| Anonymous → authenticated identity stitch documented (or explicit decision on email-match) | §4 — full stitch design; email-match treated as explicit team decision point, not a co-shipped fallback |
+| A PostHog funnel dashboard showing: Visited → Downloaded → Launched → Authed → Purchased | §5 — five-step funnel with event mapping |
+| No PII in event names or properties beyond what is explicitly needed | §7 — PII constraints |
+| Linked issue filed in Prosponsive repo for app-side instrumentation | §6 — issue template defined |
+
+---
+
+## Appendix A — File Change Inventory
+
+Complete list of files the code agent must modify or create:
+
+**New files:**
+- `js/analytics.js` — CTA click handlers, `ph_id` URL stamping, UTM reader
+
+**Modified HTML files (snippet added to `<head>`):**
+All HTML files in the repo (approximately 32 files). The code agent should `find . -name "*.html"` to get the authoritative list and add the snippet to each.
+
+**Modified HTML files (analytics.js script tag added before `</body>` and `data-cta-location` attributes added to CTAs):**
+Priority pages — those with download buttons or high-value CTAs:
+- `index.html`
+- `download/index.html`
+- `for/consultants/index.html`
+- `for/power-users/index.html`
+- `for/privacy/index.html`
+- `for/teams/index.html`
+- `how-it-works/index.html`
+- `integrations/index.html`
+- `security/index.html`
+
+Other pages (guides, compare, legal, releases, privacy, terms): add the analytics.js script tag but no CTA instrumentation is required — they contain no download buttons.
+
+**Modified JS files:**
+- `js/download.js` — the `ph_id` stamping logic lives in `analytics.js` (not in download.js itself), but `analytics.js` must execute after `download.js` has updated `btn.href`. The code agent must ensure script load order: `download.js` first, `analytics.js` second. Both load before `</body>`.
+
+**No changes to:**
+- `css/styles.css`
+- `CNAME`
+- `robots.txt`
+- `sitemap.xml`
+- Any content files
+
+## Appendix B — analytics.js Structure
+
+Skeleton for the code agent. Exact implementation details are the code agent's responsibility; this defines the required shape and event contract.
+
+```js
+(function () {
+  'use strict';
+
+  // --- UTM helper ---
+  function readUTMs() {
+    var params = new URLSearchParams(window.location.search);
+    return {
+      utm_source:   params.get('utm_source'),
+      utm_medium:   params.get('utm_medium'),
+      utm_campaign: params.get('utm_campaign'),
+      utm_content:  params.get('utm_content'),
+      utm_term:     params.get('utm_term')
+    };
+  }
+
+  // --- Platform from download URL ---
+  function platformFromHref(href) {
+    if (!href) return 'unknown';
+    if (href.indexOf('latest-win') !== -1) return 'windows';
+    if (href.indexOf('latest') !== -1) return 'macos';
+    return 'unknown';
+  }
+
+  // --- Stamp ph_id into download URL ---
+  function stampPhId(btn) {
+    if (typeof posthog === 'undefined' || !posthog.get_distinct_id) return;
+    var anonId = posthog.get_distinct_id();
+    if (!anonId) return;
+    try {
+      var url = new URL(btn.href, window.location.origin);
+      url.searchParams.set('ph_id', anonId);
+      btn.href = url.toString();
+    } catch (e) {
+      // malformed URL — skip stamping
+    }
+  }
+
+  // --- Download click handler ---
+  function bindDownloadButtons() {
+    var buttons = document.querySelectorAll('.btn-download, #download-btn');
+    for (var i = 0; i < buttons.length; i++) {
+      (function (btn) {
+        btn.addEventListener('click', function (e) {
+          e.preventDefault();
+          stampPhId(btn);
+          if (typeof posthog !== 'undefined') {
+            posthog.capture('download_click', Object.assign({
+              platform: platformFromHref(btn.href),
+              cta_location: btn.getAttribute('data-cta-location') || 'unknown'
+            }, readUTMs()));
+          }
+          window.location.href = btn.href;
+        });
+      })(buttons[i]);
+    }
+  }
+
+  // --- Secondary CTA click handler ---
+  function bindSecondaryCTAs() {
+    var ctaSelectors = [
+      '.btn-secondary',
+      '.persona-card'
+    ];
+    ctaSelectors.forEach(function (sel) {
+      var els = document.querySelectorAll(sel);
+      for (var i = 0; i < els.length; i++) {
+        (function (el) {
+          el.addEventListener('click', function () {
+            if (typeof posthog !== 'undefined') {
+              posthog.capture('cta_click', Object.assign({
+                cta_text: (el.textContent || '').trim().substring(0, 100),
+                cta_href: el.href || '',
+                cta_location: el.getAttribute('data-cta-location') || 'unknown'
+              }, readUTMs()));
+            }
+          });
+        })(els[i]);
+      }
+    });
+  }
+
+  // --- Init ---
+  function init() {
+    bindDownloadButtons();
+    bindSecondaryCTAs();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();
+```
+
+**Guard pattern:** every call to `posthog.*` in `analytics.js` is guarded by `typeof posthog !== 'undefined'`. If the CDN snippet fails to load (network error, ad blocker), the page continues to function normally. The download button must still navigate even if PostHog is unavailable — the `e.preventDefault()` / `window.location.href` sequence handles this because `stampPhId` and the capture call are guarded separately.

--- a/download/index.html
+++ b/download/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -60,6 +71,7 @@
           class="btn-download"
           href="#"
           aria-label="Download Prosponsive for macOS"
+          data-cta-location="download_page"
         >
           Download for macOS
         </a>
@@ -90,5 +102,6 @@
   </footer>
 
   <script src="../js/download.js"></script>
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/for/consultants/index.html
+++ b/for/consultants/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,7 +57,7 @@
         <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
-        <a href="/download/" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
       </nav>
     </div>
   </header>
@@ -64,8 +75,8 @@
         <h1 id="hero-heading">Set up once. Assign work. Walk away.</h1>
         <p class="persona-hero-message">You shouldn't have to manage your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-download">Download for macOS</a>
-          <a href="/how-it-works/" class="btn-secondary">See scheduled prompts</a>
+          <a href="/download/" class="btn-download" data-cta-location="home_hero">Download for macOS</a>
+          <a href="/how-it-works/" class="btn-secondary" data-cta-location="hero_secondary">See scheduled prompts</a>
         </div>
       </div>
     </section>
@@ -154,7 +165,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Your recurring work. Automated.</h2>
         <p>Set up once, assign work, walk away. Prosponsive is free to download for macOS and Windows.</p>
-        <a href="/download/" class="btn-download">Download for macOS</a>
+        <a href="/download/" class="btn-download" data-cta-location="inline">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>
@@ -174,5 +185,6 @@
     </div>
   </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/for/consultants/index.html
+++ b/for/consultants/index.html
@@ -75,7 +75,7 @@
         <h1 id="hero-heading">Set up once. Assign work. Walk away.</h1>
         <p class="persona-hero-message">You shouldn't have to manage your AI. Set up once, assign work, walk away. Prosponsive turns recurring tasks into automatic outcomes — with your data staying on your machine.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-download" data-cta-location="home_hero">Download for macOS</a>
+          <a href="/download/" class="btn-download" data-download-btn data-cta-location="home_hero">Download for macOS</a>
           <a href="/how-it-works/" class="btn-secondary" data-cta-location="hero_secondary">See scheduled prompts</a>
         </div>
       </div>
@@ -165,7 +165,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Your recurring work. Automated.</h2>
         <p>Set up once, assign work, walk away. Prosponsive is free to download for macOS and Windows.</p>
-        <a href="/download/" class="btn-download" data-cta-location="inline">Download for macOS</a>
+        <a href="/download/" class="btn-download" data-download-btn data-cta-location="inline">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>

--- a/for/power-users/index.html
+++ b/for/power-users/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,7 +57,7 @@
         <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
-        <a href="/download/" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
       </nav>
     </div>
   </header>
@@ -64,8 +75,8 @@
         <h1 id="hero-heading">Your AI stack still has you as the orchestrator.</h1>
         <p class="persona-hero-message">Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover. Built for people who know what they actually want from AI.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-download">Download for macOS</a>
-          <a href="../../guides/compare/vs-cloud-chat.html" class="btn-secondary">Compare to cloud AI</a>
+          <a href="/download/" class="btn-download" data-cta-location="home_hero">Download for macOS</a>
+          <a href="../../guides/compare/vs-cloud-chat.html" class="btn-secondary" data-cta-location="hero_secondary">Compare to cloud AI</a>
         </div>
       </div>
     </section>
@@ -172,7 +183,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Close the orchestration loop.</h2>
         <p>Download Prosponsive and run your first parallel agent workflow in minutes. macOS and Windows, free to download.</p>
-        <a href="/download/" class="btn-download">Download for macOS</a>
+        <a href="/download/" class="btn-download" data-cta-location="inline">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>
@@ -192,5 +203,6 @@
     </div>
   </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/for/power-users/index.html
+++ b/for/power-users/index.html
@@ -75,7 +75,7 @@
         <h1 id="hero-heading">Your AI stack still has you as the orchestrator.</h1>
         <p class="persona-hero-message">Your AI stack still has you as the orchestrator. Prosponsive closes the loop — parallel agents, async tools, credential isolation, and automatic failover. Built for people who know what they actually want from AI.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-download" data-cta-location="home_hero">Download for macOS</a>
+          <a href="/download/" class="btn-download" data-download-btn data-cta-location="home_hero">Download for macOS</a>
           <a href="../../guides/compare/vs-cloud-chat.html" class="btn-secondary" data-cta-location="hero_secondary">Compare to cloud AI</a>
         </div>
       </div>
@@ -183,7 +183,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Close the orchestration loop.</h2>
         <p>Download Prosponsive and run your first parallel agent workflow in minutes. macOS and Windows, free to download.</p>
-        <a href="/download/" class="btn-download" data-cta-location="inline">Download for macOS</a>
+        <a href="/download/" class="btn-download" data-download-btn data-cta-location="inline">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>

--- a/for/privacy/index.html
+++ b/for/privacy/index.html
@@ -74,7 +74,7 @@
         <h1 id="hero-heading">Sensitive work doesn't have to route through the cloud.</h1>
         <p class="persona-hero-message">Sensitive work doesn't need cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, never sent to a provider.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-download" data-cta-location="home_hero">Download for macOS</a>
+          <a href="/download/" class="btn-download" data-download-btn data-cta-location="home_hero">Download for macOS</a>
           <a href="/security/" class="btn-secondary" data-cta-location="hero_secondary">Read security architecture</a>
         </div>
       </div>
@@ -179,7 +179,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Your data stays with you.</h2>
         <p>Prosponsive is the personal autonomous agent platform built for sensitive work. Local execution, credential isolation, and local AI model support — by design.</p>
-        <a href="/download/" class="btn-download" data-cta-location="inline">Download for macOS</a>
+        <a href="/download/" class="btn-download" data-download-btn data-cta-location="inline">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>

--- a/for/privacy/index.html
+++ b/for/privacy/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,7 +56,7 @@
         <a href="/for/privacy/" aria-current="page">For Privacy</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
-        <a href="/download/" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
       </nav>
     </div>
   </header>
@@ -63,8 +74,8 @@
         <h1 id="hero-heading">Sensitive work doesn't have to route through the cloud.</h1>
         <p class="persona-hero-message">Sensitive work doesn't need cloud servers. Prosponsive runs locally — your documents, credentials, and workflows stay with you, never sent to a provider.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-download">Download for macOS</a>
-          <a href="/security/" class="btn-secondary">Read security architecture</a>
+          <a href="/download/" class="btn-download" data-cta-location="home_hero">Download for macOS</a>
+          <a href="/security/" class="btn-secondary" data-cta-location="hero_secondary">Read security architecture</a>
         </div>
       </div>
     </section>
@@ -158,7 +169,7 @@
           </table>
         </div>
         <div style="margin-top:1.5rem;">
-          <a href="/security/" class="btn-secondary">Read the full security architecture</a>
+          <a href="/security/" class="btn-secondary" data-cta-location="security_section">Read the full security architecture</a>
         </div>
       </div>
     </section>
@@ -168,7 +179,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">Your data stays with you.</h2>
         <p>Prosponsive is the personal autonomous agent platform built for sensitive work. Local execution, credential isolation, and local AI model support — by design.</p>
-        <a href="/download/" class="btn-download">Download for macOS</a>
+        <a href="/download/" class="btn-download" data-cta-location="inline">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows</p>
       </div>
     </section>
@@ -188,5 +199,6 @@
     </div>
   </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/for/teams/index.html
+++ b/for/teams/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,7 +57,7 @@
         <a href="/for/teams/" aria-current="page">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../../guides/user-guide.html">Guides</a>
-        <a href="/download/" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
       </nav>
     </div>
   </header>
@@ -64,8 +75,8 @@
         <h1 id="hero-heading">Every AI action auditable.</h1>
         <p class="persona-hero-message">Every AI action auditable. Auto-approval rules define what agents can do unattended. Credentials never touch the AI provider. Local execution by design.</p>
         <div class="persona-hero-cta">
-          <a href="/security/" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
-          <a href="/download/" class="btn-secondary">Download for macOS</a>
+          <a href="/security/" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);" data-cta-location="hero_primary">Read security architecture</a>
+          <a href="/download/" class="btn-secondary" data-cta-location="hero_secondary">Download for macOS</a>
         </div>
       </div>
     </section>
@@ -158,7 +169,7 @@
           </table>
         </div>
         <div style="margin-top:1.5rem;">
-          <a href="/security/" class="btn-secondary">Read the full security architecture</a>
+          <a href="/security/" class="btn-secondary" data-cta-location="security_section">Read the full security architecture</a>
         </div>
       </div>
     </section>
@@ -168,7 +179,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">AI governance built in, not bolted on.</h2>
         <p>Prosponsive is the personal autonomous agent platform where every AI action is auditable, credentials are isolated, and data never leaves the machine.</p>
-        <a href="/security/" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);">Read security architecture</a>
+        <a href="/security/" class="btn-download" style="background-color:#f4f6f4;color:var(--accent);" data-cta-location="inline">Read security architecture</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Or <a href="/download/" style="color:rgba(244,246,244,0.85);">download Prosponsive</a> to evaluate directly &middot; macOS &amp; Windows</p>
       </div>
     </section>
@@ -188,5 +199,6 @@
     </div>
   </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/basics.html
+++ b/guides/basics.html
@@ -8,6 +8,17 @@
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -306,5 +317,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/compare/index.html
+++ b/guides/compare/index.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive Comparisons</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -67,7 +78,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="../user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -241,5 +252,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/compare/vs-automation.html
+++ b/guides/compare/vs-automation.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive vs. Zapier and Make</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="../user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -238,5 +249,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/compare/vs-claude-cowork.html
+++ b/guides/compare/vs-claude-cowork.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive vs. Claude Cowork</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="../user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -264,5 +275,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/compare/vs-cloud-chat.html
+++ b/guides/compare/vs-cloud-chat.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive vs. ChatGPT, Claude.ai, and Gemini</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="../user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -234,5 +245,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/compare/vs-copilot-workspace.html
+++ b/guides/compare/vs-copilot-workspace.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive vs. Microsoft Copilot and Google Workspace AI</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="../user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -243,5 +254,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/compare/vs-custom-agents.html
+++ b/guides/compare/vs-custom-agents.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive vs. Custom GPTs and OpenAI Assistants</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="../user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -255,5 +266,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/compare/vs-local-models.html
+++ b/guides/compare/vs-local-models.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive vs. Ollama, LM Studio, and GPT4All</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="../user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -236,5 +247,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/compare/vs-openclaw.html
+++ b/guides/compare/vs-openclaw.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive vs. OpenClaw</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="../user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -305,5 +316,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/email-assistant-example.html
+++ b/guides/email-assistant-example.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive — Example: Email Assistant</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -409,5 +420,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/features.html
+++ b/guides/features.html
@@ -20,6 +20,17 @@
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <style>
   body, .vscode-body, .markdown-body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Helvetica Neue', sans-serif;
@@ -75,7 +86,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -550,5 +561,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/feedback.html
+++ b/guides/feedback.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive — Feedback &amp; Philosophy</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -184,5 +195,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/install-guide.html
+++ b/guides/install-guide.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive Install Guide</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -263,5 +274,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/n8n-tool-building-guide.html
+++ b/guides/n8n-tool-building-guide.html
@@ -44,6 +44,17 @@
   .tip strong { color: #2F4F3E; }
   .section-number { color: #4F6F5C; font-weight: 400; }
   </style>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
 </head>
 <body class="page-wrapper">
 
@@ -60,7 +71,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -449,5 +460,6 @@ POST /api/ai/agent-inference
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/n8n-workflow-developer-guide.html
+++ b/guides/n8n-workflow-developer-guide.html
@@ -47,6 +47,17 @@
   .guide-nav a { text-decoration: none; color: #2F4F3E; font-weight: 500; }
   .guide-nav a:hover { text-decoration: underline; }
   </style>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
 </head>
 <body class="page-wrapper">
 
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -455,5 +466,6 @@ POST /api/ai/agent-inference
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/security-architecture-whitepaper.html
+++ b/guides/security-architecture-whitepaper.html
@@ -5,6 +5,17 @@
   <meta name="robots" content="noindex, nofollow">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive Security Architecture White Paper</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
@@ -1513,5 +1524,6 @@ form-action 'none';</code></pre>
   <em>This document is confidential and intended solely for the use of the organization to whom it was provided for the purpose of security evaluation. Redistribution without written consent from Prosponsive, Inc. is prohibited.</em>
 </div>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/guides/user-guide.html
+++ b/guides/user-guide.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive User Guide</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
@@ -63,7 +74,7 @@
       <a href="/for/teams/">For Teams</a>
       <a href="/how-it-works/">How It Works</a>
       <a href="user-guide.html">Guides</a>
-      <a href="/download/" class="nav-cta">Download</a>
+      <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
     </nav>
   </div>
 </header>
@@ -126,5 +137,6 @@
   </div>
 </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/how-it-works/index.html
+++ b/how-it-works/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,7 +57,7 @@
         <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/" aria-current="page">How It Works</a>
         <a href="../guides/user-guide.html">Guides</a>
-        <a href="/download/" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
       </nav>
     </div>
   </header>
@@ -65,8 +76,8 @@
         <h1 id="hero-heading">The bottleneck isn't the model. It's the architecture.</h1>
         <p class="persona-hero-message">Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. Here's why that matters and how it works.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-download">Download for macOS</a>
-          <a href="../guides/user-guide.html" class="btn-secondary">Read the user guide</a>
+          <a href="/download/" class="btn-download" data-cta-location="home_hero">Download for macOS</a>
+          <a href="../guides/user-guide.html" class="btn-secondary" data-cta-location="hero_secondary">Read the user guide</a>
         </div>
       </div>
     </section>
@@ -170,25 +181,25 @@
         <h2 id="routing-heading" class="section-heading">Find your path</h2>
         <p class="section-subheading">Prosponsive was built for different kinds of knowledge workers. Find what matters most for how you work.</p>
         <div class="persona-grid" style="grid-template-columns:repeat(2,1fr);">
-          <a href="/for/power-users/" class="persona-card">
+          <a href="/for/power-users/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">Developer / Power User</div>
             <h3>Close the orchestration gap</h3>
             <p>Parallel agents, async tools, credential isolation, and automatic failover — for people who already know what they want from AI.</p>
             <span class="persona-card-arrow">For developers and power users &rarr;</span>
           </a>
-          <a href="/for/consultants/" class="persona-card">
+          <a href="/for/consultants/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">Independent Professional</div>
             <h3>Set up once. Walk away.</h3>
             <p>Turn recurring tasks into automatic outcomes. Briefings, digests, monitoring — with your data staying on your machine.</p>
             <span class="persona-card-arrow">For consultants and freelancers &rarr;</span>
           </a>
-          <a href="/for/privacy/" class="persona-card">
+          <a href="/for/privacy/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">Privacy-Conscious Professional</div>
             <h3>Data sovereignty by design</h3>
             <p>Sensitive work doesn't have to route through cloud servers. Local execution, credential isolation, encrypted at rest.</p>
             <span class="persona-card-arrow">For legal, finance, HR, and healthcare &rarr;</span>
           </a>
-          <a href="/for/teams/" class="persona-card">
+          <a href="/for/teams/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">IT / Security Decision Maker</div>
             <h3>Every AI action auditable</h3>
             <p>Auto-approval rules, credential isolation, local execution — governance built in, not bolted on.</p>
@@ -203,7 +214,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">AI That Works While You Don't</h2>
         <p>Prosponsive is the personal autonomous agent platform that runs AI assistants locally on your desktop. Free to download for macOS and Windows. 7+ AI providers. 2,533 tools. 12 languages.</p>
-        <a href="/download/" class="btn-download">Download for macOS</a>
+        <a href="/download/" class="btn-download" data-cta-location="inline">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows &middot; 12 languages</p>
       </div>
     </section>
@@ -223,5 +234,6 @@
     </div>
   </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/how-it-works/index.html
+++ b/how-it-works/index.html
@@ -76,7 +76,7 @@
         <h1 id="hero-heading">The bottleneck isn't the model. It's the architecture.</h1>
         <p class="persona-hero-message">Your AI agents actually work while you don't — running tools in the background, in parallel, with your data staying on your machine. Here's why that matters and how it works.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-download" data-cta-location="home_hero">Download for macOS</a>
+          <a href="/download/" class="btn-download" data-download-btn data-cta-location="home_hero">Download for macOS</a>
           <a href="../guides/user-guide.html" class="btn-secondary" data-cta-location="hero_secondary">Read the user guide</a>
         </div>
       </div>
@@ -214,7 +214,7 @@
       <div class="section-inner">
         <h2 id="cta-heading">AI That Works While You Don't</h2>
         <p>Prosponsive is the personal autonomous agent platform that runs AI assistants locally on your desktop. Free to download for macOS and Windows. 7+ AI providers. 2,533 tools. 12 languages.</p>
-        <a href="/download/" class="btn-download" data-cta-location="inline">Download for macOS</a>
+        <a href="/download/" class="btn-download" data-download-btn data-cta-location="inline">Download for macOS</a>
         <p style="margin-top:0.75rem;font-size:0.875rem;color:rgba(244,246,244,0.75);">Free to download &middot; macOS &amp; Windows &middot; 12 languages</p>
       </div>
     </section>

--- a/index.html
+++ b/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -73,7 +84,7 @@
         <a href="/for/privacy/">For Privacy</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="guides/user-guide.html">Guides</a>
-        <a href="/download/" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
       </nav>
     </div>
   </header>
@@ -154,7 +165,7 @@
             <p>Async tools, parallel agents, auto-approvals, and scheduled prompts eliminate task babysitting. Post a task and walk away. Results are waiting when you return.</p>
             <p>Most AI tools are synchronous — you type and then you wait for your agent to let you participate again. It's one synchronous step at a time. Prosponsive runs multiple specialized agents in parallel, executing tools in the background while you focus on work that matters.</p>
             <div class="pillar-cta">
-              <a href="/how-it-works/" class="btn-secondary">See how it works</a>
+              <a href="/how-it-works/" class="btn-secondary" data-cta-location="how_it_works_section">See how it works</a>
             </div>
           </div>
           <div class="pillar-metrics-panel" aria-label="Pillar 01 metrics">
@@ -182,7 +193,7 @@
             </div>
             <p>The agent runtime, tool execution, and storage all run on your machine — your files, keys, and workflow state stay local even though LLMs are remote and tools can call external APIs. Your credentials never touch an AI provider. And if one model goes down, Prosponsive automatically fails over to the next.</p>
             <div class="pillar-cta">
-              <a href="/security/" class="btn-secondary">Read security architecture</a>
+              <a href="/security/" class="btn-secondary" data-cta-location="security_section">Read security architecture</a>
             </div>
           </div>
           <div class="pillar-metrics-panel" aria-label="Pillar 02 metrics">
@@ -211,7 +222,7 @@
             <p><a href="https://n8n.io" target="_blank" rel="noopener">n8n</a> workflows orchestrate multiple systems per agent call. 2,533 tools across 216 products — one agent call executes a complete workflow: read a ticket, look up the customer, check billing, and draft the response as a single operation.</p>
             <p>Not trigger-action automation. Not single MCP calls. Prosponsive agents use n8n-powered tools that coordinate across your real systems — Salesforce, NetSuite, Workday, ServiceNow — in one step, with 60–80% fewer tool calls compared to equivalent MCP stacks.</p>
             <div class="pillar-cta">
-              <a href="/integrations/" class="btn-secondary">Browse integrations</a>
+              <a href="/integrations/" class="btn-secondary" data-cta-location="integrations_section">Browse integrations</a>
             </div>
           </div>
           <div class="pillar-metrics-panel" aria-label="Pillar 03 metrics">
@@ -241,31 +252,31 @@
         <h2 id="personas-heading" class="section-heading" style="text-align:center;margin-bottom:0.5rem;">Built for your workflow</h2>
         <p class="section-subheading" style="text-align:center;margin:0 auto 2.5rem;">Find your fit — each path leads to what matters most for how you work.</p>
         <div class="persona-grid">
-          <a href="/for/power-users/" class="persona-card">
+          <a href="/for/power-users/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">Developer / Power User</div>
             <h3>Close the orchestration gap</h3>
             <p>Your AI stack still has you as the orchestrator. Parallel agents, async tools, credential isolation, and automatic failover — built for people who know what they want from AI.</p>
             <span class="persona-card-arrow">For developers and power users &rarr;</span>
           </a>
-          <a href="/for/consultants/" class="persona-card">
+          <a href="/for/consultants/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">Independent Professional</div>
             <h3>Set up once. Walk away.</h3>
             <p>You shouldn't have to manage your AI. Turn recurring tasks into automatic outcomes — briefings, digests, monitoring — with your data staying on your machine.</p>
             <span class="persona-card-arrow">For consultants and freelancers &rarr;</span>
           </a>
-          <a href="/for/privacy/" class="persona-card">
+          <a href="/for/privacy/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">Privacy-Conscious Professional</div>
             <h3>Data sovereignty by design</h3>
             <p>Sensitive work doesn't have to route through cloud servers. Your documents, credentials, and workflows stay with you — not with a provider.</p>
             <span class="persona-card-arrow">For legal, finance, HR, and healthcare &rarr;</span>
           </a>
-          <a href="/for/teams/" class="persona-card">
+          <a href="/for/teams/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">IT / Security Decision Maker</div>
             <h3>Every AI action auditable</h3>
             <p>Auto-approval rules define what agents can do without human review. Credentials never touch the AI provider. Local execution by design.</p>
             <span class="persona-card-arrow">For IT and security leaders &rarr;</span>
           </a>
-          <a href="/how-it-works/" class="persona-card">
+          <a href="/how-it-works/" class="persona-card" data-cta-location="persona_grid">
             <div class="persona-card-tier">Curious Professional</div>
             <h3>A team of specialists in a group chat</h3>
             <p>AI should work while you don't. Drop a task and come back to results, not process. No code. No babysitting. Just outcomes.</p>
@@ -294,5 +305,6 @@
     </div>
   </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/integrations/index.html
+++ b/integrations/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -46,7 +57,7 @@
         <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../guides/user-guide.html">Guides</a>
-        <a href="/download/" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
       </nav>
     </div>
   </header>
@@ -1054,6 +1065,7 @@
     </div>
   </footer>
 
+  <script src="/js/analytics.js"></script>
   <script>
     (function () {
       var searchInput = document.getElementById('catalog-search');

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,104 @@
+(function () {
+  'use strict';
+
+  // --- UTM helper ---
+  function readUTMs() {
+    var params = new URLSearchParams(window.location.search);
+    return {
+      utm_source:   params.get('utm_source'),
+      utm_medium:   params.get('utm_medium'),
+      utm_campaign: params.get('utm_campaign'),
+      utm_content:  params.get('utm_content'),
+      utm_term:     params.get('utm_term')
+    };
+  }
+
+  // --- Platform from download URL ---
+  // download.js sets btn.href to a CloudFront URL ending in /latest (macOS)
+  // or /latest-win (Windows). Derive platform from that suffix.
+  function platformFromHref(href) {
+    if (!href) return 'unknown';
+    if (href.indexOf('latest-win') !== -1) return 'windows';
+    if (href.indexOf('latest') !== -1) return 'macos';
+    return 'unknown';
+  }
+
+  // --- Stamp ph_id into download URL ---
+  // Appends ?ph_id=<posthog.get_distinct_id()> so the installer URL carries
+  // the anonymous web visitor ID for the identity stitch at first app launch.
+  function stampPhId(btn) {
+    if (typeof posthog === 'undefined' || !posthog.get_distinct_id) return;
+    var anonId = posthog.get_distinct_id();
+    if (!anonId) return;
+    try {
+      var url = new URL(btn.href, window.location.origin);
+      url.searchParams.set('ph_id', anonId);
+      btn.href = url.toString();
+    } catch (e) {
+      // malformed URL — skip stamping
+    }
+  }
+
+  // --- Download click handler ---
+  // Binds to .btn-download and #download-btn. On click: prevents default
+  // navigation, stamps ph_id into the href, captures the download_click event,
+  // then programmatically follows the link. This ordering ensures the URL is
+  // stamped before navigation proceeds.
+  function bindDownloadButtons() {
+    var buttons = document.querySelectorAll('.btn-download, #download-btn');
+    for (var i = 0; i < buttons.length; i++) {
+      (function (btn) {
+        btn.addEventListener('click', function (e) {
+          e.preventDefault();
+          stampPhId(btn);
+          if (typeof posthog !== 'undefined') {
+            posthog.capture('download_click', Object.assign({
+              platform: platformFromHref(btn.href),
+              cta_location: btn.getAttribute('data-cta-location') || 'unknown'
+            }, readUTMs()));
+          }
+          window.location.href = btn.href;
+        });
+      })(buttons[i]);
+    }
+  }
+
+  // --- Secondary CTA click handler ---
+  // Captures cta_click on .btn-secondary, .persona-card, and .nav-cta elements.
+  // These are high-intent engagement signals (not primary download buttons).
+  function bindSecondaryCTAs() {
+    var ctaSelectors = [
+      '.btn-secondary',
+      '.persona-card',
+      '.nav-cta'
+    ];
+    ctaSelectors.forEach(function (sel) {
+      var els = document.querySelectorAll(sel);
+      for (var i = 0; i < els.length; i++) {
+        (function (el) {
+          el.addEventListener('click', function () {
+            if (typeof posthog !== 'undefined') {
+              posthog.capture('cta_click', Object.assign({
+                cta_text: (el.textContent || '').trim().substring(0, 100),
+                cta_href: el.href || '',
+                cta_location: el.getAttribute('data-cta-location') || 'unknown'
+              }, readUTMs()));
+            }
+          });
+        })(els[i]);
+      }
+    });
+  }
+
+  // --- Init ---
+  function init() {
+    bindDownloadButtons();
+    bindSecondaryCTAs();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -40,24 +40,49 @@
   }
 
   // --- Download click handler ---
-  // Binds to .btn-download and #download-btn. On click: prevents default
-  // navigation, stamps ph_id into the href, captures the download_click event,
-  // then programmatically follows the link. This ordering ensures the URL is
-  // stamped before navigation proceeds.
+  // Binds to [data-download-btn] and #download-btn. On click: distinguishes
+  // between real installer URLs (CloudFront, /latest, /latest-win) and
+  // navigation links to the /download/ page.
+  //
+  // Installer URLs: prevent default, stamp ph_id, capture download_click, then
+  // follow the link. This ordering ensures ph_id is stamped before navigation.
+  //
+  // Page navigation URLs (/download/): let the browser follow naturally and
+  // capture a cta_click (like other secondary CTAs) — no ph_id stamping and
+  // no preventDefault, since the download page reconstructs the installer URL
+  // from scratch and the stitch would be lost anyway.
+  function isInstallerUrl(href) {
+    return href.indexOf('cloudfront.net') !== -1
+      || href.indexOf('/latest') !== -1; // covers /latest and /latest-win
+  }
+
   function bindDownloadButtons() {
-    var buttons = document.querySelectorAll('.btn-download, #download-btn');
+    var buttons = document.querySelectorAll('[data-download-btn], #download-btn');
     for (var i = 0; i < buttons.length; i++) {
       (function (btn) {
         btn.addEventListener('click', function (e) {
-          e.preventDefault();
-          stampPhId(btn);
-          if (typeof posthog !== 'undefined') {
-            posthog.capture('download_click', Object.assign({
-              platform: platformFromHref(btn.href),
-              cta_location: btn.getAttribute('data-cta-location') || 'unknown'
-            }, readUTMs()));
+          var href = btn.href || '';
+          if (isInstallerUrl(href)) {
+            e.preventDefault();
+            stampPhId(btn);
+            if (typeof posthog !== 'undefined') {
+              posthog.capture('download_click', Object.assign({
+                platform: platformFromHref(btn.href),
+                cta_location: btn.getAttribute('data-cta-location') || 'unknown'
+              }, readUTMs()));
+            }
+            window.location.href = btn.href;
+          } else {
+            // Navigation to /download/ page — let browser follow naturally,
+            // track as CTA intent only.
+            if (typeof posthog !== 'undefined') {
+              posthog.capture('cta_click', Object.assign({
+                cta_text: (btn.textContent || '').trim().substring(0, 100),
+                cta_href: href,
+                cta_location: btn.getAttribute('data-cta-location') || 'unknown'
+              }, readUTMs()));
+            }
           }
-          window.location.href = btn.href;
         });
       })(buttons[i]);
     }
@@ -78,8 +103,11 @@
         (function (el) {
           el.addEventListener('click', function () {
             if (typeof posthog !== 'undefined') {
+              var text = el.classList.contains('persona-card')
+                ? (el.querySelector('h3') || el).textContent.trim()
+                : (el.textContent || '').trim().substring(0, 100);
               posthog.capture('cta_click', Object.assign({
-                cta_text: (el.textContent || '').trim().substring(0, 100),
+                cta_text: text,
                 cta_href: el.href || '',
                 cta_location: el.getAttribute('data-cta-location') || 'unknown'
               }, readUTMs()));

--- a/legal/index.html
+++ b/legal/index.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Legal — Prosponsive</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <link rel="icon" href="/assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="/assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="/assets/icon.png?v=2026-05-04">
@@ -35,5 +46,6 @@
     <p>Machine-readable current-version manifest: <a href="/legal/versions.json">/legal/versions.json</a>.</p>
     <p>For privacy requests or concerns, email <a href="mailto:privacy@prosponsive.ai">privacy@prosponsive.ai</a>.</p>
   </main>
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/privacy/2026-04-24/index.html
+++ b/privacy/2026-04-24/index.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Privacy Policy — Prosponsive</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <meta name="description" content="Privacy Policy for the Prosponsive desktop application, version 2026-04-24.">
   <link rel="icon" href="/assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="/assets/favicon.ico?v=2026-05-04">
@@ -72,7 +83,8 @@
 <h3>4.2 Information we collect automatically</h3>
 <ul>
 <li><strong>IP address, at the network edge:</strong> When you download the Prosponsive installer or auto-update package from Amazon CloudFront, AWS sees your IP address as part of normal network routing. We have disabled CloudFront access logging, so we do not retain IP addresses in any access logs we control.</li>
-<li><strong>Device and usage analytics (opt-in only):</strong> If you opt in to analytics, we use PostHog to record event data tied to a randomly generated UUID — we do not associate it with your account, your name, or your email, and we have disabled IP-based geolocation so PostHog does not persist coarse location data on our events. The events cover: feature-usage actions (e.g., conversation lifecycle and tool approvals — including the tool name but not its inputs or outputs, and the length of a message in characters but not its content); basic device and operating-system information; basic AI configuration (the provider and model you're currently using and your configured failover list); and the application's runtime state (app version, container runtime, session timing). For stuck or error events we additionally send a sanitized log tail — file paths, IP addresses, email addresses, and values that look like API keys are stripped before sending. You can opt out at any time in Settings; opting out stops any further events from being sent.</li>
+<li><strong>Marketing website analytics:</strong> The <code>prosponsive.ai</code> marketing website uses PostHog to collect anonymized page view and CTA click data. PostHog assigns a randomly generated UUID on your first visit (stored in localStorage and a browser cookie) and records which pages you visited and which buttons you clicked. No email address, name, or other personally identifiable information is collected. No session recording is enabled. This data is used solely to understand how visitors navigate the site and which download paths are most effective. It is not opt-in; if you prefer not to be tracked, you can block third-party scripts in your browser settings.</li>
+<li><strong>Desktop application analytics (opt-in only):</strong> If you opt in to analytics in the Prosponsive desktop application, we use PostHog to record event data tied to a randomly generated UUID — we do not associate it with your account, your name, or your email, and we have disabled IP-based geolocation so PostHog does not persist coarse location data on our events. The events cover: feature-usage actions (e.g., conversation lifecycle and tool approvals — including the tool name but not its inputs or outputs, and the length of a message in characters but not its content); basic device and operating-system information; basic AI configuration (the provider and model you're currently using and your configured failover list); and the application's runtime state (app version, container runtime, session timing). For stuck or error events we additionally send a sanitized log tail — file paths, IP addresses, email addresses, and values that look like API keys are stripped before sending. You can opt out at any time in Settings; opting out stops any further events from being sent.</li>
 <li><strong>Acceptance records:</strong> When you accept this Privacy Policy or our Terms of Service, we record your user ID, the document you accepted, the version, the timestamp, and the application version. We also record a salted SHA-256 hash of your IP address (not the raw IP) and the user agent string. The hash is computed at our API gateway using a server-side pepper that is never logged. These records are append-only and are retained indefinitely for legal defensibility (see §9).</li>
 </ul>
 <h3>4.3 Information generated by your use of the app</h3>
@@ -204,5 +216,6 @@
       <a href="/legal/">All legal documents</a>
     </nav>
   </main>
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -9,8 +9,20 @@
   <meta http-equiv="refresh" content="0; url=/privacy/2026-04-24/">
   <link rel="canonical" href="https://prosponsive.ai/privacy/2026-04-24/">
   <script>window.location.replace('/privacy/2026-04-24/');</script>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
 </head>
 <body>
   <p>Redirecting to the current <a href="/privacy/2026-04-24/">Privacy Policy</a>…</p>
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -9,20 +9,8 @@
   <meta http-equiv="refresh" content="0; url=/privacy/2026-04-24/">
   <link rel="canonical" href="https://prosponsive.ai/privacy/2026-04-24/">
   <script>window.location.replace('/privacy/2026-04-24/');</script>
-  <script>
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('__POSTHOG_API_KEY__', {
-      api_host: 'https://us.i.posthog.com',
-      autocapture: false,
-      capture_pageview: true,
-      persistence: 'localStorage+cookie',
-      cross_subdomain_cookie: false,
-      disable_session_recording: true
-    });
-  </script>
 </head>
 <body>
   <p>Redirecting to the current <a href="/privacy/2026-04-24/">Privacy Policy</a>…</p>
-  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/releases/index.html
+++ b/releases/index.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Prosponsive — Release Notes</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <meta name="description" content="What's new in Prosponsive. Release notes and changelog for every version.">
   <link rel="icon" href="../assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
@@ -330,5 +341,6 @@
       <a href="../guides/feedback.html">Feedback</a>
     </nav>
   </footer>
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/security/index.html
+++ b/security/index.html
@@ -18,6 +18,17 @@
   <link rel="alternate icon" href="../assets/favicon.ico?v=2026-05-04">
   <link rel="apple-touch-icon" href="../assets/icon.png?v=2026-05-04">
   <link rel="stylesheet" href="../css/styles.css">
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <script type="module">
     import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
     mermaid.initialize({ startOnLoad: true, theme: 'neutral' });
@@ -50,7 +61,7 @@
         <a href="/for/teams/">For Teams</a>
         <a href="/how-it-works/">How It Works</a>
         <a href="../guides/user-guide.html">Guides</a>
-        <a href="/download/" class="nav-cta">Download</a>
+        <a href="/download/" class="nav-cta" data-cta-location="nav">Download</a>
       </nav>
     </div>
   </header>
@@ -68,7 +79,7 @@
         <h1 id="hero-heading">Security by architecture, not policy.</h1>
         <p class="persona-hero-message">Local execution. Isolated tool runtime. Zero server-side data storage. Here's how it works.</p>
         <div class="persona-hero-cta">
-          <a href="/download/" class="btn-secondary">Download free</a>
+          <a href="/download/" class="btn-secondary" data-cta-location="hero_secondary">Download free</a>
         </div>
       </div>
     </section>
@@ -256,7 +267,7 @@ graph LR
       <div class="section-inner">
         <h2 id="cta-heading">Built for sensitive work.</h2>
         <p>Download Prosponsive and see the security model in action. Local execution. Free.</p>
-        <a href="/download/" class="btn-download">Download free</a>
+        <a href="/download/" class="btn-download" data-cta-location="inline">Download free</a>
       </div>
     </section>
 
@@ -275,5 +286,6 @@ graph LR
     </div>
   </footer>
 
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/security/index.html
+++ b/security/index.html
@@ -267,7 +267,7 @@ graph LR
       <div class="section-inner">
         <h2 id="cta-heading">Built for sensitive work.</h2>
         <p>Download Prosponsive and see the security model in action. Local execution. Free.</p>
-        <a href="/download/" class="btn-download" data-cta-location="inline">Download free</a>
+        <a href="/download/" class="btn-download" data-download-btn data-cta-location="inline">Download free</a>
       </div>
     </section>
 

--- a/terms/2026-04-24/index.html
+++ b/terms/2026-04-24/index.html
@@ -4,6 +4,17 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Terms of Service — Prosponsive</title>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
   <meta name="description" content="Terms of Service for the Prosponsive desktop application, version 2026-04-24.">
   <link rel="icon" href="/assets/prosponsive-logo-icon.svg?v=2026-05-04" type="image/svg+xml">
   <link rel="alternate icon" href="/assets/favicon.ico?v=2026-05-04">
@@ -179,5 +190,6 @@
       <a href="/legal/">All legal documents</a>
     </nav>
   </main>
+  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/terms/index.html
+++ b/terms/index.html
@@ -9,20 +9,8 @@
   <meta http-equiv="refresh" content="0; url=/terms/2026-04-24/">
   <link rel="canonical" href="https://prosponsive.ai/terms/2026-04-24/">
   <script>window.location.replace('/terms/2026-04-24/');</script>
-  <script>
-    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
-    posthog.init('__POSTHOG_API_KEY__', {
-      api_host: 'https://us.i.posthog.com',
-      autocapture: false,
-      capture_pageview: true,
-      persistence: 'localStorage+cookie',
-      cross_subdomain_cookie: false,
-      disable_session_recording: true
-    });
-  </script>
 </head>
 <body>
   <p>Redirecting to the current <a href="/terms/2026-04-24/">Terms of Service</a>…</p>
-  <script src="/js/analytics.js"></script>
 </body>
 </html>

--- a/terms/index.html
+++ b/terms/index.html
@@ -9,8 +9,20 @@
   <meta http-equiv="refresh" content="0; url=/terms/2026-04-24/">
   <link rel="canonical" href="https://prosponsive.ai/terms/2026-04-24/">
   <script>window.location.replace('/terms/2026-04-24/');</script>
+  <script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(a!==void 0?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return a!==void 0&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString()+" (stub people)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a]),e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('__POSTHOG_API_KEY__', {
+      api_host: 'https://us.i.posthog.com',
+      autocapture: false,
+      capture_pageview: true,
+      persistence: 'localStorage+cookie',
+      cross_subdomain_cookie: false,
+      disable_session_recording: true
+    });
+  </script>
 </head>
 <body>
   <p>Redirecting to the current <a href="/terms/2026-04-24/">Terms of Service</a>…</p>
+  <script src="/js/analytics.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Instruments the Prosponsive.ai marketing site with PostHog analytics, enabling measurement of the full user acquisition funnel from first web visit through to download.

- Adds the PostHog CDN async snippet to all 32 HTML pages with `autocapture: false`, `capture_pageview: true`, `disable_session_recording: true` — automatic page view tracking on every page, no session recording
- Creates `js/analytics.js` — explicit click event capture for download buttons (`download_click`) and secondary CTAs (`cta_click`), with UTM attribution on every event
- Stamps the PostHog anonymous `distinct_id` as `?ph_id=<uuid>` into installer download URLs at click time, enabling cross-surface identity stitching when the app reads it at first launch (app-side instrumentation deferred to Prosponsive#2023)
- Uses `data-download-btn` attribute (not the CSS class) to bind download handlers, preventing false `download_click` events on styled-but-non-download links
- API key is a `__POSTHOG_API_KEY__` build-time placeholder — no key hardcoded

## Identity stitch design

Web visit → `ph_id` stamped in download URL → app reads `ph_id` at first launch → `posthog.alias()` → Clerk `identify()` → Stripe webhook → unified person profile in PostHog. Steps 3–5 (app-side) tracked in Prosponsive#2023.

## Test plan

- [ ] Confirm `__POSTHOG_API_KEY__` is substituted at deploy time (GitHub Pages / CI env)
- [ ] Open any page — PostHog `$pageview` event fires in PostHog Live Events
- [ ] Click a download button on `download/index.html` — `download_click` event fires with `platform: macos|windows`, `cta_location: download_page`
- [ ] Click a hero CTA — `cta_click` event fires with correct `cta_location`
- [ ] Block PostHog CDN (uBlock) — download still proceeds normally, no JS errors
- [ ] Verify `ph_id` appears in the download URL query string after clicking download

## Linked issues

- Closes #88
- App-side instrumentation: Prosponsive#2023

🤖 Generated with [Claude Code](https://claude.com/claude-code)