### PR TITLE
fix(seo): disallow crawling of legal/versions.json

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,5 +2,6 @@ User-agent: *
 Allow: /
 Disallow: /guides/security-architecture-whitepaper.html
 Disallow: /linkedin-security-review-message.html
+Disallow: /legal/versions.json
 
 Sitemap: https://prosponsive.ai/sitemap.xml


### PR DESCRIPTION
## What

Adds one line to `robots.txt`:

```
Disallow: /legal/versions.json
```

## Why

Google Search Console listed `https://prosponsive.ai/legal/versions.json` under **"Crawled – currently not indexed."** It's a **data file** (the privacy/terms version manifest the legal pages read), not a page — it should never be indexed. Disallowing it removes it from Google's crawl and clears it from the indexing reports.

No page content affected; the legal pages fetch this file client-side regardless of robots rules (robots only governs crawlers, not the site's own fetches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)